### PR TITLE
LFLT-466 Missing exception handler for unauthorized API calls

### DIFF
--- a/acceptance/src/test/resources/features/password_reset.feature
+++ b/acceptance/src/test/resources/features/password_reset.feature
@@ -57,7 +57,6 @@ Feature: Password reset flow tests
      Then the application responds with HTTP status OK
       And the response body contains "You've provided incorrect information, please check and try again"
 
-  @Ignore # TODO re-enable after LFLT-466
   @NegativeScenario
   Scenario: Requesting password reset with failed ReCaptcha
 

--- a/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/BaseController.java
+++ b/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/BaseController.java
@@ -1,5 +1,6 @@
 package hu.psprog.leaflet.lags.web.rest.controller;
 
+import hu.psprog.leaflet.lags.core.exception.AuthenticationException;
 import hu.psprog.leaflet.lags.core.exception.OAuthAuthorizationException;
 import hu.psprog.leaflet.lags.web.model.AuthorizationError;
 import lombok.extern.slf4j.Slf4j;
@@ -31,11 +32,27 @@ public class BaseController {
      */
     @ExceptionHandler(OAuthAuthorizationException.class)
     public ResponseEntity<AuthorizationError> handleAuthorizationException(OAuthAuthorizationException exception) {
+        return handleException(exception, HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * Exception handler for {@link AuthenticationException}s and {@link org.springframework.security.core.AuthenticationException}s.
+     * Logs the exception and wraps the message into a JSON response, along with an HTTP 401 Unauthorized status code.
+     *
+     * @param exception {@link Exception} object
+     * @return response entity object containing the error message in {@link AuthorizationError} object
+     */
+    @ExceptionHandler({AuthenticationException.class, org.springframework.security.core.AuthenticationException.class})
+    public ResponseEntity<AuthorizationError> handleAuthenticationException(Exception exception) {
+        return handleException(exception, HttpStatus.UNAUTHORIZED);
+    }
+
+    private ResponseEntity<AuthorizationError> handleException(Exception exception, HttpStatus httpStatus) {
 
         log.error(exception.getMessage());
 
         return ResponseEntity
-                .status(HttpStatus.FORBIDDEN)
+                .status(httpStatus)
                 .body(new AuthorizationError(exception.getMessage()));
     }
 }

--- a/web/src/test/java/hu/psprog/leaflet/lags/web/rest/controller/BaseControllerTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/lags/web/rest/controller/BaseControllerTest.java
@@ -1,13 +1,19 @@
 package hu.psprog.leaflet.lags.web.rest.controller;
 
+import hu.psprog.leaflet.lags.core.exception.AuthenticationException;
 import hu.psprog.leaflet.lags.core.exception.OAuthAuthorizationException;
+import hu.psprog.leaflet.lags.core.exception.RevokedTokenException;
 import hu.psprog.leaflet.lags.web.model.AuthorizationError;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import java.lang.reflect.InvocationTargetException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,6 +42,27 @@ class BaseControllerTest {
 
         // then
         assertThat(result.getStatusCode(), equalTo(HttpStatus.FORBIDDEN));
+        assertThat(result.getBody(), equalTo(expectedAuthorizationError));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            AuthenticationException.class,
+            RevokedTokenException.class
+    })
+    public void shouldHandleAuthenticationException(Class<? extends Exception> exceptionClass)
+            throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+
+        // given
+        String exceptionMessage = "Authentication failed";
+        Exception exception = exceptionClass.getConstructor(String.class).newInstance(exceptionMessage);
+        AuthorizationError expectedAuthorizationError = new AuthorizationError(exceptionMessage);
+
+        // when
+        ResponseEntity<AuthorizationError> result = baseController.handleAuthenticationException(exception);
+
+        // then
+        assertThat(result.getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
         assertThat(result.getBody(), equalTo(expectedAuthorizationError));
     }
 }


### PR DESCRIPTION
 - Added exception handler for internal domain and Spring MVC AuthenticationExceptions resolving to 401
 - Re-enabled affected password reset acceptance test scenario