### PR TITLE
LFLT-470 Show authorized scope on OAuth authorization UI

### DIFF
--- a/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/OAuth2AuthenticationController.java
+++ b/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/OAuth2AuthenticationController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +26,9 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static hu.psprog.leaflet.lags.web.rest.controller.BaseController.PATH_OAUTH_AUTHORIZE;
 import static hu.psprog.leaflet.lags.web.rest.controller.BaseController.PATH_OAUTH_INTROSPECT;
@@ -74,6 +77,7 @@ public class OAuth2AuthenticationController {
         return new ModelAndView(VIEW_AUTHORIZE, Map.of(
                 "name", userDetails.getName(),
                 "email", userDetails.getUsername(),
+                "authorizedScope", extractScope(userDetails),
                 "logoutRef", createLogoutReference(request)
         ));
     }
@@ -123,6 +127,13 @@ public class OAuth2AuthenticationController {
     @PostMapping(PATH_OAUTH_INTROSPECT)
     public ResponseEntity<TokenIntrospectionResult> introspectToken(@RequestParam String token) {
         return ResponseEntity.ok(oAuthAuthorizationService.introspect(token));
+    }
+
+    private List<String> extractScope(ExtendedUser userDetails) {
+
+        return userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
     }
 
     private String createLogoutReference(HttpServletRequest request) {

--- a/web/src/main/resources/webapp/resources/css/site.css
+++ b/web/src/main/resources/webapp/resources/css/site.css
@@ -8,7 +8,8 @@
 }
 
 .psprog-logo-container {
-    width: 162px !important;
+    width: 200px !important;
+    text-align: center;
 }
 
 .validationError {

--- a/web/src/main/resources/webapp/templates/views/authorize.html
+++ b/web/src/main/resources/webapp/templates/views/authorize.html
@@ -10,7 +10,13 @@
                 <div class="col-12 mt-3" style="text-align: center;">
                     <h3>Welcome back,<br /><span style="font-weight: bold;" th:text="${name}"></span></h3>
                     <p>(<span th:text="${email}"></span>)</p>
-                    <p>In order to return to psprog.hu, click the Continue button.</p>
+                    <p>You are going to give the application permission to use the following of your authorities:</p>
+                    <ul class="list-group list-group-flush" style="font-size: small;">
+                        <li class="list-group-item align-items-baseline py-0" style="text-align: left;"
+                            th:each="scope : ${authorizedScope}"
+                            th:text="#{'form.authorize.scope.' + ${scope}}">scope</li>
+                    </ul>
+                    <p class="pt-1">In order to return to psprog.hu, click the Continue button.</p>
                 </div>
             </div>
             <div class="row justify-content-center">


### PR DESCRIPTION
 - Controller is now passing the authorized scope set to the authorization UI
 - UI shows the list of authorized scope, being prepared for translation
 - Fixed logo sizing
 - Aligned relevant unit test case