### PR TITLE
LFLT-488 LAGS saves user locale during sign up differently than how Leaflet expects

### DIFF
--- a/acceptance/src/test/resources/data.sql
+++ b/acceptance/src/test/resources/data.sql
@@ -11,5 +11,5 @@ values
     (1, @CREATED_DATE, true, 'EN', 'test-admin@ac-leaflet.local', 'ADMIN', 'Administrator', @TEST_PW, 'LOCAL'),
     (2, @CREATED_DATE, true, 'EN', 'test-user-1@ac-leaflet.local', 'USER', 'Test User 1', @TEST_PW, 'LOCAL'),
     (3, @CREATED_DATE, true, 'EN', 'test-editor-2@ac-leaflet.local', 'EDITOR', 'Test Editor 2', @TEST_PW, 'LOCAL'),
-    (4, @CREATED_DATE, true, 'EN', 'test-editor-3@ac-leaflet.local', 'EDITOR', 'Test Editor 3', @TEST_PW, 'LOCAL'),
-    (5, @CREATED_DATE, true, 'EN', 'test-editor-pwgrant@ac-leaflet.local', 'EDITOR', 'Test Editor PW Grant', @TEST_PW, 'LOCAL');
+    (4, @CREATED_DATE, true, 'HU', 'test-editor-3@ac-leaflet.local', 'EDITOR', 'Test Editor 3', @TEST_PW, 'LOCAL'),
+    (5, @CREATED_DATE, true, 'HU', 'test-editor-pwgrant@ac-leaflet.local', 'EDITOR', 'Test Editor PW Grant', @TEST_PW, 'LOCAL');

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/config/AuthenticationConfig.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/config/AuthenticationConfig.java
@@ -1,10 +1,9 @@
 package hu.psprog.leaflet.lags.core.config;
 
+import hu.psprog.leaflet.lags.core.domain.entity.SupportedLocale;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import java.util.Locale;
 
 /**
  * Authentication configuration parameters model.
@@ -23,7 +22,7 @@ import java.util.Locale;
 public class AuthenticationConfig {
 
     private boolean userEnabledByDefault = true;
-    private Locale defaultLocale = Locale.forLanguageTag("HU");
+    private SupportedLocale defaultLocale = SupportedLocale.HU;
     private String recaptchaSecret;
     private String recaptchaSiteKey;
     private PasswordResetConfig passwordReset;

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/conversion/SignUpRequestModelToUserConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/conversion/SignUpRequestModelToUserConverter.java
@@ -38,7 +38,7 @@ public class SignUpRequestModelToUserConverter implements Converter<SignUpReques
                 .password(passwordEncoder.encode(signUpRequestModel.getPassword()))
                 .enabled(authenticationConfig.isUserEnabledByDefault())
                 .created(new Date())
-                .defaultLocale(authenticationConfig.getDefaultLocale().toString())
+                .defaultLocale(authenticationConfig.getDefaultLocale())
                 .role(Role.USER)
                 .accountType(AccountType.LOCAL)
                 .build();

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/SupportedLocale.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/SupportedLocale.java
@@ -1,0 +1,36 @@
+package hu.psprog.leaflet.lags.core.domain.entity;
+
+import java.util.Locale;
+
+/**
+ * Locales with language codes.
+ *
+ * @author Peter Smith
+ */
+public enum SupportedLocale {
+
+    /**
+     * Hungarian.
+     */
+    HU(Locale.forLanguageTag("HU")),
+
+    /**
+     * English (United States).
+     */
+    EN(Locale.US);
+
+    private final Locale locale;
+
+    SupportedLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    /**
+     * Returns the JDK {@link Locale} object assigned to a specific supported locale.
+     *
+     * @return assigned JDK {@link Locale} object
+     */
+    public Locale getLocale() {
+        return locale;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/User.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/User.java
@@ -59,7 +59,8 @@ public class User {
     private String password;
 
     @Column(name = DatabaseConstants.COLUMN_DEFAULT_LOCALE)
-    private String defaultLocale;
+    @Enumerated(EnumType.STRING)
+    private SupportedLocale defaultLocale;
 
     @Column(name = DatabaseConstants.COLUMN_ACCOUNT_TYPE)
     @Enumerated(EnumType.STRING)

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/conversion/SignUpRequestModelToUserConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/conversion/SignUpRequestModelToUserConverterTest.java
@@ -3,6 +3,7 @@ package hu.psprog.leaflet.lags.core.conversion;
 import hu.psprog.leaflet.lags.core.config.AuthenticationConfig;
 import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
 import hu.psprog.leaflet.lags.core.domain.entity.Role;
+import hu.psprog.leaflet.lags.core.domain.entity.SupportedLocale;
 import hu.psprog.leaflet.lags.core.domain.entity.User;
 import hu.psprog.leaflet.lags.core.domain.request.SignUpRequestModel;
 import org.junit.jupiter.api.Test;
@@ -11,8 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -33,7 +32,7 @@ class SignUpRequestModelToUserConverterTest {
     private static final String EMAIL = "user@dev.local";
     private static final String PASSWORD = "password1";
     private static final boolean USER_ENABLED_BY_DEFAULT = true;
-    private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+    private static final SupportedLocale DEFAULT_LOCALE = SupportedLocale.EN;
     private static final String ENCODED_PASSWORD = "encoded-password";
     private static final SignUpRequestModel SIGN_UP_REQUEST_MODEL = new SignUpRequestModel();
 
@@ -69,7 +68,7 @@ class SignUpRequestModelToUserConverterTest {
         assertThat(result.getEmail(), equalTo(EMAIL));
         assertThat(result.getPassword(), equalTo(ENCODED_PASSWORD));
         assertThat(result.isEnabled(), is(USER_ENABLED_BY_DEFAULT));
-        assertThat(result.getDefaultLocale(), equalTo(DEFAULT_LOCALE.toString()));
+        assertThat(result.getDefaultLocale(), equalTo(DEFAULT_LOCALE));
         assertThat(result.getRole(), equalTo(Role.USER));
         assertThat(result.getAccountType(), equalTo(AccountType.LOCAL));
         assertThat(System.currentTimeMillis() - result.getCreated().getTime() < 100, is(true));


### PR DESCRIPTION
 - Added the SupportedLocale enum with possible values of HU and EN
 - Aligned User entity class
 - Aligned default locale configuration
 - Aligned relevant unit test case