### PR TITLE
LFLT-487 Missing scope for reading own comments in LAGS' role to authority mapper

### DIFF
--- a/acceptance/src/test/resources/application-acceptance.yml
+++ b/acceptance/src/test/resources/application-acceptance.yml
@@ -124,6 +124,7 @@ oauth2-config:
       client-secret: frontapp4455
       audience: dummy:acceptance:app:frontapp:test
       required-scopes:
+        - read:comments:own
         - read:users:own
         - write:comments:own
         - write:users:own
@@ -136,6 +137,7 @@ oauth2-config:
       client-secret: mockleaflet1234
       audience: dummy:acceptance:svc:mockleaflet:test
       registered-scopes:
+        - read:comments:own
         - read:users:own
         - write:comments:own
         - write:users:own
@@ -156,6 +158,7 @@ oauth2-config:
       allowed-clients:
         - name: lmsmock
           allowed-scopes:
+            - read:comments:own
             - read:users:own
             - write:comments:own
             - write:users:own
@@ -175,6 +178,7 @@ oauth2-config:
             - write:users
         - name: frontapp
           allowed-scopes:
+            - read:comments:own
             - read:users:own
             - write:comments:own
             - write:users:own

--- a/acceptance/src/test/resources/features/authorization_code_authorization.feature
+++ b/acceptance/src/test/resources/features/authorization_code_authorization.feature
@@ -80,7 +80,7 @@ Feature: OAuth2 Authorization Code authorization flow tests
      Then the application responds with HTTP status OK
       And the response contains a token
       And the returned token expires in 30 seconds
-      And the returned token gives access to scope read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags read:admin read:users write:admin write:users
+      And the returned token gives access to scope read:comments:own read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags read:admin read:users write:admin write:users
       And the returned token is a Bearer type token
 
   @PositiveScenario
@@ -110,7 +110,7 @@ Feature: OAuth2 Authorization Code authorization flow tests
      Then the application responds with HTTP status OK
       And the response contains a token
       And the returned token expires in 30 seconds
-      And the returned token gives access to scope read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags
+      And the returned token gives access to scope read:comments:own read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags
       And the returned token is a Bearer type token
 
   @PositiveScenario
@@ -140,7 +140,7 @@ Feature: OAuth2 Authorization Code authorization flow tests
      Then the application responds with HTTP status OK
       And the response contains a token
       And the returned token expires in 30 seconds
-      And the returned token gives access to scope read:users:own write:comments:own write:users:own
+      And the returned token gives access to scope read:comments:own read:users:own write:comments:own write:users:own
       And the returned token is a Bearer type token
 
   @PositiveScenario
@@ -170,7 +170,7 @@ Feature: OAuth2 Authorization Code authorization flow tests
      Then the application responds with HTTP status OK
       And the response contains a token
       And the returned token expires in 30 seconds
-      And the returned token gives access to scope read:users:own write:comments:own write:users:own
+      And the returned token gives access to scope read:comments:own read:users:own write:comments:own write:users:own
       And the returned token is a Bearer type token
 
   @NegativeScenario
@@ -180,7 +180,7 @@ Feature: OAuth2 Authorization Code authorization flow tests
       And the response type is set to code
       And the application requests redirection to http://localhost:9291/mock/admin
       And the sent state value is state-4437
-      And the client requests access for scope read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags
+      And the client requests access for scope read:comments:own read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags
       And the user is signed in as test-user-1@ac-leaflet.local with password testpw01
 
      When the authorization is requested

--- a/acceptance/src/test/resources/features/resource_owner_authorization.feature
+++ b/acceptance/src/test/resources/features/resource_owner_authorization.feature
@@ -15,7 +15,7 @@ Feature: OAuth2 Resource Owner (Password Grant) authorization flow tests
      Then the application responds with HTTP status OK
       And the response contains a token
       And the returned token expires in 30 seconds
-      And the returned token gives access to scope read:users:own write:comments:own write:users:own
+      And the returned token gives access to scope read:comments:own read:users:own write:comments:own write:users:own
       And the returned token is a Bearer type token
 
   @PositiveScenario
@@ -52,7 +52,7 @@ Feature: OAuth2 Resource Owner (Password Grant) authorization flow tests
      Then the application responds with HTTP status OK
       And the response contains a token
       And the returned token expires in 30 seconds
-      And the returned token gives access to scope read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags
+      And the returned token gives access to scope read:comments:own read:users:own write:comments:own write:users:own read:categories read:comments read:documents read:entries read:tags write:categories write:comments write:documents write:entries write:tags
       And the returned token is a Bearer type token
 
   @NegativeScenario

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistry.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistry.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 public class StaticRoleToAuthorityMappingRegistry implements RoleToAuthorityMappingRegistry {
 
     private static final String[] USER_AUTHORITIES = {
+            "read:comments:own",
             "read:users:own",
             "write:comments:own",
             "write:users:own"

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistryTest.java
@@ -33,6 +33,7 @@ class StaticRoleToAuthorityMappingRegistryTest {
 
         // then
         assertThat(result, equalTo(AuthorityUtils.createAuthorityList(
+                "read:comments:own",
                 "read:users:own",
                 "write:comments:own",
                 "write:users:own"
@@ -47,6 +48,7 @@ class StaticRoleToAuthorityMappingRegistryTest {
 
         // then
         assertThat(result, equalTo(AuthorityUtils.createAuthorityList(
+                "read:comments:own",
                 "read:users:own",
                 "write:comments:own",
                 "write:users:own",
@@ -71,6 +73,7 @@ class StaticRoleToAuthorityMappingRegistryTest {
 
         // then
         assertThat(result, equalTo(AuthorityUtils.createAuthorityList(
+                "read:comments:own",
                 "read:users:own",
                 "write:comments:own",
                 "write:users:own",


### PR DESCRIPTION
 - Added missing read:comments:own scope to the role mapper
 - Aligned affected unit and acceptance test cases