### PR TITLE
LFLT-459 Add 3rd party login possibility to LAGS starting with GitHub account

### DIFF
--- a/acceptance/pom.xml
+++ b/acceptance/pom.xml
@@ -80,6 +80,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/acceptance/pom.xml
+++ b/acceptance/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.0-dev</version>
+        <version>1.1.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stepdefs/AuthenticationStepDefinition.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stepdefs/AuthenticationStepDefinition.java
@@ -1,10 +1,20 @@
 package hu.psprog.leaflet.lags.acceptance.stepdefs;
 
 import hu.psprog.leaflet.lags.acceptance.model.TestConstants;
+import hu.psprog.leaflet.lags.acceptance.stub.ExternalAuthenticationMock;
 import hu.psprog.leaflet.lags.acceptance.utility.LAGSClient;
 import hu.psprog.leaflet.lags.acceptance.utility.ThreadLocalDataRegistry;
 import io.cucumber.java8.En;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Step definition implementation for standard user authentication related test scenarios.
@@ -16,13 +26,16 @@ public class AuthenticationStepDefinition implements En {
     private static final String SUCCESSFUL_RECAPTCHA_KEYWORD = "succeeded";
 
     private final LAGSClient lagsClient;
+    private final ExternalAuthenticationMock externalAuthenticationMock;
 
     @Autowired
-    public AuthenticationStepDefinition(LAGSClient lagsClient) {
+    public AuthenticationStepDefinition(LAGSClient lagsClient, ExternalAuthenticationMock externalAuthenticationMock) {
         this.lagsClient = lagsClient;
+        this.externalAuthenticationMock = externalAuthenticationMock;
 
         defineConditions();
         defineActions();
+        defineAssertions();
     }
 
     private void defineConditions() {
@@ -46,6 +59,9 @@ public class AuthenticationStepDefinition implements En {
                     : "invalidToken");
             ThreadLocalDataRegistry.putFlag(TestConstants.Flag.USE_RECAPTCHA_VERIFICATION);
         });
+
+        Given("^the external user uses the email address (.*)$",
+                (String email) -> ThreadLocalDataRegistry.put(TestConstants.Attribute.EMAIL, email));
     }
 
     private void defineActions() {
@@ -58,5 +74,58 @@ public class AuthenticationStepDefinition implements En {
 
         When("^the user signs out$",
                 () -> ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestSignOut()));
+
+        When("^the user requests sign-in via (GitHub)$", (String provider) -> {
+
+            ExternalAuthenticationMock.Provider resolvedProvider = ExternalAuthenticationMock.Provider.valueOf(provider.toUpperCase());
+            ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestExternalLogin(resolvedProvider));
+        });
+
+        When("^the user authorizes access on (GitHub)$", (String provider) -> {
+
+            ExternalAuthenticationMock.Provider resolvedProvider = ExternalAuthenticationMock.Provider.valueOf(provider.toUpperCase());
+            externalAuthenticationMock.registerProviderMock(resolvedProvider);
+            ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestExternalLoginReturn(resolvedProvider, true));
+            externalAuthenticationMock.resetProviderMock();
+        });
+
+        When("^the user rejects access on (GitHub)$", (String provider) -> {
+
+            ExternalAuthenticationMock.Provider resolvedProvider = ExternalAuthenticationMock.Provider.valueOf(provider.toUpperCase());
+            externalAuthenticationMock.registerProviderMock(resolvedProvider);
+            ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestExternalLoginReturn(resolvedProvider, false));
+            externalAuthenticationMock.resetProviderMock();
+        });
+
+        When("^the user is returned to the authorization page$",
+                () -> ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestAuthorizationPage()));
+    }
+
+    private void defineAssertions() {
+
+        Then("^the external user is logged in as (.*)$", (String username) -> {
+
+            String usernameSection = String.format("<span style=\"font-weight: bold;\">%s</span>", username);
+            ResponseEntity<String> response = ThreadLocalDataRegistry.getResponseEntity();
+            assertThat(response.getBody(), notNullValue());
+            assertThat(response.getBody().contains(usernameSection), is(true));
+        });
+
+        Then("^the external user is logged in with the email address (.*)$", (String email) -> {
+
+            String emailSection = String.format("<p>(<span>%s</span>)</p>", email);
+            ResponseEntity<String> response = ThreadLocalDataRegistry.getResponseEntity();
+            assertThat(response.getBody(), notNullValue());
+            assertThat(response.getBody().contains(emailSection), is(true));
+        });
+
+        Then("^the external user has the scopes ([a-z: ]+)$", (String scope) -> {
+
+            ResponseEntity<String> response = ThreadLocalDataRegistry.getResponseEntity();
+            assertThat(response.getBody(), notNullValue());
+            List<String> scopes = List.of(scope.split(StringUtils.SPACE));
+            assertThat(StringUtils.countMatches(response.getBody(), "??form.authorize.scope."), equalTo(scopes.size()));
+            scopes.forEach(scopeItem -> assertThat(response.getBody().contains(String.format("??form.authorize.scope.%s_hu_HU??", scopeItem)), is(true)));
+        });
     }
 }

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stub/ExternalAuthenticationMock.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stub/ExternalAuthenticationMock.java
@@ -1,0 +1,144 @@
+package hu.psprog.leaflet.lags.acceptance.stub;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import hu.psprog.leaflet.lags.acceptance.model.TestConstants;
+import hu.psprog.leaflet.lags.acceptance.utility.HTTPUtility;
+import hu.psprog.leaflet.lags.acceptance.utility.ThreadLocalDataRegistry;
+import hu.psprog.leaflet.lags.core.domain.internal.GitHubEmailItem;
+import hu.psprog.leaflet.lags.core.domain.response.OAuthTokenResponse;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+/**
+ * WireMock based mock server component for simulating external OAuth provider based login flows.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class ExternalAuthenticationMock {
+
+    private static final int WIREMOCK_PORT = 9290;
+    private static final int EXPIRES_IN = 3600;
+    private static final int EXTERNAL_USER_ID = 558890;
+    private static final String EXTERNAL_USER_NAME = "Test User";
+
+    private WireMockServer wireMockServer;
+
+    @PostConstruct
+    public void setup() {
+
+        wireMockServer = new WireMockServer(options().port(WIREMOCK_PORT));
+        if (!wireMockServer.isRunning()) {
+            wireMockServer.start();
+            configureFor(WIREMOCK_PORT);
+        }
+    }
+
+    @PreDestroy
+    public void tearDown() {
+        wireMockServer.stop();
+    }
+
+    /**
+     * Initializes the mock endpoints for the given provider.
+     *
+     * @param forProvider provider identifier as {@link Provider} enum constant
+     */
+    public void registerProviderMock(Provider forProvider) {
+
+        registerTokenEndpoint(forProvider.getTokenEndpoint());
+        registerUserInfoEndpoint(forProvider.getUserinfoEndpoint());
+        forProvider.getFurtherRegistrations()
+                .forEach(Runnable::run);
+    }
+
+    /**
+     * Resets all registered mock endpoints.
+     */
+    public void resetProviderMock() {
+        WireMock.reset();
+        wireMockServer.resetAll();
+    }
+
+    private static void registerTokenEndpoint(String tokenEndpoint) {
+
+        URI location = ThreadLocalDataRegistry.getResponseEntity().getHeaders().getLocation();
+        String scope = HTTPUtility.getQueryParameter(location, TestConstants.Attribute.SCOPE);
+
+        givenThat(post(tokenEndpoint)
+                .willReturn(jsonResponse(OAuthTokenResponse.builder()
+                        .accessToken(UUID.randomUUID().toString())
+                        .expiresIn(EXPIRES_IN)
+                        .scope(scope)
+                        .build(), 200)));
+    }
+
+    private static void registerUserInfoEndpoint(String userInfoEndpoint) {
+
+        givenThat(get(userInfoEndpoint)
+                .willReturn(jsonResponse(Map.of(
+                        "name", EXTERNAL_USER_NAME,
+                        "sub", EXTERNAL_USER_ID,
+                        "id", EXTERNAL_USER_ID
+                ), 200)));
+    }
+
+    private static void registerGitHubEmailsEndpoint() {
+
+        givenThat(get("/githubmock/user/emails")
+                .willReturn(jsonResponse(List.of(
+                        prepareGitHubEmailItem("ghuser1-non-primary@dev.local", false),
+                        prepareGitHubEmailItem(ThreadLocalDataRegistry.get(TestConstants.Attribute.EMAIL), true)
+                ), 200)));
+    }
+
+    private static GitHubEmailItem prepareGitHubEmailItem(String email, boolean primary) {
+
+        GitHubEmailItem emailItem = new GitHubEmailItem();
+        emailItem.setEmail(email);
+        emailItem.setPrimary(primary);
+
+        return emailItem;
+    }
+
+    public enum Provider {
+
+        GITHUB("/githubmock/token", "/githubmock/userinfo", List.of(ExternalAuthenticationMock::registerGitHubEmailsEndpoint));
+
+        private final String tokenEndpoint;
+        private final String userinfoEndpoint;
+        private final List<Runnable> furtherRegistrations;
+
+        Provider(String tokenEndpoint, String userinfoEndpoint, List<Runnable> furtherRegistrations) {
+            this.tokenEndpoint = tokenEndpoint;
+            this.userinfoEndpoint = userinfoEndpoint;
+            this.furtherRegistrations = furtherRegistrations;
+        }
+
+        public String getTokenEndpoint() {
+            return tokenEndpoint;
+        }
+
+        public String getUserinfoEndpoint() {
+            return userinfoEndpoint;
+        }
+
+        public List<Runnable> getFurtherRegistrations() {
+            return furtherRegistrations;
+        }
+    }
+}

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/utility/HTTPUtility.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/utility/HTTPUtility.java
@@ -1,9 +1,12 @@
 package hu.psprog.leaflet.lags.acceptance.utility;
 
 import hu.psprog.leaflet.lags.acceptance.model.TestConstants;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Utilities for HTTP call related operations..
@@ -30,6 +33,19 @@ public class HTTPUtility {
                 .get(queryParameterName.getValue())
                 .stream()
                 .findFirst()
+                .map(value -> URLDecoder.decode(value, StandardCharsets.UTF_8))
                 .orElse(null);
+    }
+
+    /**
+     * Extracts the value of the {@code Set-Cookie} header from the currently stored {@link ResponseEntity} object.
+     *
+     * @return value of the {@code Set-Cookie} header
+     */
+    public static String extractCookieFromResponse() {
+
+        return ThreadLocalDataRegistry.getResponseEntity()
+                .getHeaders()
+                .getFirst("Set-Cookie");
     }
 }

--- a/acceptance/src/test/resources/application-acceptance.yml
+++ b/acceptance/src/test/resources/application-acceptance.yml
@@ -25,6 +25,20 @@ spring:
     defer-datasource-initialization: true
   main:
     allow-bean-definition-overriding: true
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: test-client-1
+            client-secret: client-secret-1
+            scope:
+              - read:user
+              - user:email
+        provider:
+          github:
+            token-uri: http://localhost:9290/githubmock/token
+            user-info-uri: http://localhost:9290/githubmock/userinfo
 
 logging:
   pattern:
@@ -38,6 +52,8 @@ tms:
 
 bridge:
   clients:
+    github:
+      host-url: http://localhost:9290/githubmock
     tms:
       host-url: http://localhost:9290/mock/tms
 

--- a/acceptance/src/test/resources/data.sql
+++ b/acceptance/src/test/resources/data.sql
@@ -12,4 +12,5 @@ values
     (2, @CREATED_DATE, true, 'EN', 'test-user-1@ac-leaflet.local', 'USER', 'Test User 1', @TEST_PW, 'LOCAL'),
     (3, @CREATED_DATE, true, 'EN', 'test-editor-2@ac-leaflet.local', 'EDITOR', 'Test Editor 2', @TEST_PW, 'LOCAL'),
     (4, @CREATED_DATE, true, 'HU', 'test-editor-3@ac-leaflet.local', 'EDITOR', 'Test Editor 3', @TEST_PW, 'LOCAL'),
-    (5, @CREATED_DATE, true, 'HU', 'test-editor-pwgrant@ac-leaflet.local', 'EDITOR', 'Test Editor PW Grant', @TEST_PW, 'LOCAL');
+    (5, @CREATED_DATE, true, 'HU', 'test-editor-pwgrant@ac-leaflet.local', 'EDITOR', 'Test Editor PW Grant', @TEST_PW, 'LOCAL'),
+    (6, @CREATED_DATE, true, 'HU', 'test-user-github@ac-leaflet.local', 'EXTERNAL_USER', 'Test External User GitHub', null, 'GITHUB');

--- a/acceptance/src/test/resources/features/authentication.feature
+++ b/acceptance/src/test/resources/features/authentication.feature
@@ -50,8 +50,18 @@ Feature: Standard user sign-in flow tests
 
      When the user signs in
 
-    Then the application responds with HTTP status FOUND
-     And the user is redirected to /login?auth=fail
+     Then the application responds with HTTP status FOUND
+      And the user is redirected to /login?auth=fail
+
+  @NegativeScenario
+  Scenario: Failed login attempt with non-local user via local sign-in flow
+
+    Given the user identifies with the email address test-user-github@ac-leaflet.local
+
+     When the user signs in
+
+     Then the application responds with HTTP status FOUND
+      And the user is redirected to /login?auth=fail
 
   @NegativeScenario
   Scenario: Failed login attempt with invalid password
@@ -61,8 +71,8 @@ Feature: Standard user sign-in flow tests
 
      When the user signs in
 
-    Then the application responds with HTTP status FOUND
-     And the user is redirected to /login?auth=fail
+     Then the application responds with HTTP status FOUND
+      And the user is redirected to /login?auth=fail
 
   @NegativeScenario
   Scenario: A new user tries to sign up with an address already in use

--- a/acceptance/src/test/resources/features/external_authentication.feature
+++ b/acceptance/src/test/resources/features/external_authentication.feature
@@ -1,0 +1,47 @@
+Feature: External provider based user sign-in flow tests
+
+  @PositiveScenario
+  Scenario: Successfully signing-in with a GitHub account for the first time
+
+    Given the external user uses the email address ghuser1-primary@dev.local
+
+     When the user requests sign-in via GitHub
+      And the user authorizes access on GitHub
+      And the user is returned to the authorization page
+
+     Then the external user is logged in as Test User
+      And the external user is logged in with the email address ghuser1-primary@dev.local
+      And the external user has the scopes read:comments:own read:users:own write:comments:own
+
+  @PositiveScenario
+  Scenario: Successfully returning with a GitHub account
+
+    Given the external user uses the email address test-user-github@ac-leaflet.local
+
+     When the user requests sign-in via GitHub
+      And the user authorizes access on GitHub
+      And the user is returned to the authorization page
+
+     Then the external user is logged in as Test External User GitHub
+      And the external user is logged in with the email address test-user-github@ac-leaflet.local
+      And the external user has the scopes read:comments:own read:users:own write:comments:own
+
+  @NegativeScenario
+  Scenario: Sign-up is not possible via external provider with an already used email address from a different source
+
+    Given the external user uses the email address test-user-1@ac-leaflet.local
+
+     When the user requests sign-in via GitHub
+      And the user authorizes access on GitHub
+
+     Then the user is redirected to /login?ext_auth=ADDRESS_IN_USE
+
+  @NegativeScenario
+  Scenario: User rejects access on GitHub
+
+    Given the external user uses the email address ghuser1-primary@dev.local
+
+     When the user requests sign-in via GitHub
+      And the user rejects access on GitHub
+
+     Then the user is redirected to /login?ext_auth=FAILURE

--- a/acceptance/src/test/resources/features/password_reset.feature
+++ b/acceptance/src/test/resources/features/password_reset.feature
@@ -47,6 +47,18 @@ Feature: Password reset flow tests
       And the user does not receive the PASSWORD_RESET_REQUEST_MAIL mail
 
   @NegativeScenario
+  Scenario: Requesting password reset with a non-local user
+
+    Given the user identifies with the email address test-user-github@ac-leaflet.local
+      And ReCaptcha verification succeeded
+
+     When the user requests password reset
+
+     Then the application responds with HTTP status OK
+      And the UI notifies the user about the accepted password reset request
+      And the user does not receive the PASSWORD_RESET_REQUEST_MAIL mail
+
+  @NegativeScenario
   Scenario: Requesting password reset with incorrect email
 
     Given the user identifies with the email address invalid-email-address

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.0-dev</version>
+        <version>1.1.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,6 +19,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/config/CoreConfiguration.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/config/CoreConfiguration.java
@@ -1,9 +1,14 @@
 package hu.psprog.leaflet.lags.core.config;
 
 import hu.psprog.leaflet.mail.config.MailComponentConfig;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 /**
  * Service layer configuration.
@@ -14,4 +19,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Import(MailComponentConfig.class)
 @EnableScheduling
 public class CoreConfiguration {
+
+    @Bean
+    public OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService() {
+        return new DefaultOAuth2UserService();
+    }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/config/SecurityConfiguration.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/config/SecurityConfiguration.java
@@ -5,22 +5,25 @@ import hu.psprog.leaflet.lags.core.security.OAuthAccessTokenAuthenticationFilter
 import hu.psprog.leaflet.lags.core.security.RequestSavingLogoutSuccessHandler;
 import hu.psprog.leaflet.lags.core.security.ReturnToAuthorizationAfterLogoutAuthenticationSuccessHandler;
 import hu.psprog.leaflet.lags.core.service.token.TokenHandler;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.ForwardAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -42,10 +45,11 @@ import static hu.psprog.leaflet.lags.core.domain.internal.SecurityConstants.RECL
 @Configuration
 @EnableWebSecurity
 @EnableConfigurationProperties(OAuthConfigurationProperties.class)
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     private static final String PATH_OAUTH_ROOT = "/oauth/**";
     private static final String PATH_LOGIN_FAILURE = "/login?auth=fail";
+    private static final String PATH_LOGIN_EXTERNAL = "/login/external";
     private static final String PATH_LOGOUT = "/logout";
     private static final String PATH_WELL_KNOWN_ROOT = "/.well-known/**";
     private static final String USERNAME_PARAMETER = "email";
@@ -53,57 +57,39 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private static final String RESOURCE_CSS = "/css/**";
     private static final String RESOURCE_JS = "/js/**";
 
-    private final UserDetailsService localUserUserDetailsService;
-    private final UserDetailsService oAuthClientUserDetailsService;
-    private final AuthenticationProvider accessTokenAuthenticationProvider;
-    private final TokenHandler tokenHandler;
-
-    @Autowired
-    public SecurityConfiguration(@Qualifier("localUserUserDetailsService") UserDetailsService localUserUserDetailsService,
-                                 @Qualifier("OAuthClientUserDetailsService") UserDetailsService oAuthClientUserDetailsService,
-                                 AuthenticationProvider accessTokenAuthenticationProvider, TokenHandler tokenHandler) {
-        this.localUserUserDetailsService = localUserUserDetailsService;
-        this.oAuthClientUserDetailsService = oAuthClientUserDetailsService;
-        this.accessTokenAuthenticationProvider = accessTokenAuthenticationProvider;
-        this.tokenHandler = tokenHandler;
-    }
-
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public AuthenticationProvider oAuthClientAuthenticationProvider(PasswordEncoder passwordEncoder) {
+    public AuthenticationProvider oAuthClientAuthenticationProvider(@Qualifier("OAuthClientUserDetailsService") UserDetailsService oAuthClientUserDetailsService,
+                                                                    PasswordEncoder passwordEncoder) {
         return createAuthenticationProvider(passwordEncoder, oAuthClientUserDetailsService);
     }
 
     @Bean
-    public AuthenticationProvider localUserAuthenticationProvider(PasswordEncoder passwordEncoder) {
+    public AuthenticationProvider localUserAuthenticationProvider(@Qualifier("localUserUserDetailsService") UserDetailsService localUserUserDetailsService,
+                                                                  PasswordEncoder passwordEncoder) {
         return createAuthenticationProvider(passwordEncoder, localUserUserDetailsService);
     }
 
     @Bean
-    @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
+    public AuthenticationManager authenticationManager(AuthenticationProvider oAuthClientAuthenticationProvider,
+                                                       AuthenticationProvider localUserAuthenticationProvider,
+                                                       AuthenticationProvider accessTokenAuthenticationProvider) {
+        return new ProviderManager(oAuthClientAuthenticationProvider, localUserAuthenticationProvider, accessTokenAuthenticationProvider);
     }
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager,
+                                                   TokenHandler tokenHandler, OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService,
+                                                   AuthenticationFailureHandler externalSignUpAuthenticationFailureHandler,
+                                                   ReturnToAuthorizationAfterLogoutAuthenticationSuccessHandler returnToAuthorizationAfterLogoutAuthenticationSuccessHandler) throws Exception {
 
-        auth
-                .authenticationProvider(oAuthClientAuthenticationProvider(passwordEncoder()))
-                .authenticationProvider(localUserAuthenticationProvider(passwordEncoder()))
-                .authenticationProvider(accessTokenAuthenticationProvider);
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-
-        http
-                .addFilterBefore(passwordResetAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(userInfoAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+        return http
+                .addFilterBefore(passwordResetAuthenticationFilter(authenticationManager, tokenHandler), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(userInfoAuthenticationFilter(authenticationManager, tokenHandler), UsernamePasswordAuthenticationFilter.class)
 
                 .authorizeRequests()
                     .antMatchers(PATH_OAUTH_ROOT)
@@ -121,7 +107,16 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .loginPage(PATH_LOGIN)
                     .failureUrl(PATH_LOGIN_FAILURE)
                     .usernameParameter(USERNAME_PARAMETER)
-                    .successHandler(new ReturnToAuthorizationAfterLogoutAuthenticationSuccessHandler())
+                    .successHandler(returnToAuthorizationAfterLogoutAuthenticationSuccessHandler)
+                    .and()
+
+                .oauth2Login()
+                    .loginPage(PATH_LOGIN_EXTERNAL)
+                    .successHandler(returnToAuthorizationAfterLogoutAuthenticationSuccessHandler)
+                    .failureHandler(externalSignUpAuthenticationFailureHandler)
+                    .userInfoEndpoint()
+                        .userService(oAuth2UserService)
+                        .and()
                     .and()
 
                 .logout()
@@ -135,7 +130,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .and()
 
                 .sessionManagement()
-                    .sessionCreationPolicy(SessionCreationPolicy.NEVER);
+                    .sessionCreationPolicy(SessionCreationPolicy.NEVER)
+                    .and()
+
+                .build();
     }
 
     private RequestSavingLogoutSuccessHandler getLogoutSuccessHandler() {
@@ -156,21 +154,21 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return authenticationProvider;
     }
 
-    private OAuthAccessTokenAuthenticationFilter passwordResetAuthenticationFilter() throws Exception {
+    private OAuthAccessTokenAuthenticationFilter passwordResetAuthenticationFilter(AuthenticationManager authenticationManager, TokenHandler tokenHandler) {
 
         OAuthAccessTokenAuthenticationFilter filter = new OAuthAccessTokenAuthenticationFilter(tokenHandler, PATH_PASSWORD_RESET_CONFIRMATION,
                 request -> request.getParameter(QUERY_PARAMETER_TOKEN));
-        filter.setAuthenticationManager(authenticationManagerBean());
+        filter.setAuthenticationManager(authenticationManager);
         filter.setAuthenticationFailureHandler(new ForwardAuthenticationFailureHandler(PATH_ACCESS_DENIED));
 
         return filter;
     }
 
-    private OAuthAccessTokenAuthenticationFilter userInfoAuthenticationFilter() throws Exception {
+    private OAuthAccessTokenAuthenticationFilter userInfoAuthenticationFilter(AuthenticationManager authenticationManager, TokenHandler tokenHandler) {
 
         OAuthAccessTokenAuthenticationFilter filter = new OAuthAccessTokenAuthenticationFilter(tokenHandler, PATH_OAUTH_USERINFO,
                 request -> request.getHeader(AUTHORIZATION_HEADER));
-        filter.setAuthenticationManager(authenticationManagerBean());
+        filter.setAuthenticationManager(authenticationManager);
 
         return filter;
     }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/config/SecurityConfiguration.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/config/SecurityConfiguration.java
@@ -69,7 +69,7 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public AuthenticationProvider localUserAuthenticationProvider(@Qualifier("localUserUserDetailsService") UserDetailsService localUserUserDetailsService,
+    public AuthenticationProvider localUserAuthenticationProvider(@Qualifier("nonExternalLocalUserUserDetailsService") UserDetailsService localUserUserDetailsService,
                                                                   PasswordEncoder passwordEncoder) {
         return createAuthenticationProvider(passwordEncoder, localUserUserDetailsService);
     }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/conversion/ExternalUserDefinitionToUserConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/conversion/ExternalUserDefinitionToUserConverter.java
@@ -1,0 +1,48 @@
+package hu.psprog.leaflet.lags.core.conversion;
+
+import hu.psprog.leaflet.lags.core.config.AuthenticationConfig;
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.request.SignUpRequestModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+/**
+ * Converts {@link SignUpRequestModel} model to {@link User} value object.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class ExternalUserDefinitionToUserConverter implements Converter<ExternalUserDefinition<?>, User> {
+
+    private static final String EXTERNAL_ID_TEMPLATE = "provider=%s|ext_uid=%s";
+
+    private final AuthenticationConfig authenticationConfig;
+
+    @Autowired
+    public ExternalUserDefinitionToUserConverter(AuthenticationConfig authenticationConfig) {
+        this.authenticationConfig = authenticationConfig;
+    }
+
+    @Override
+    public User convert(ExternalUserDefinition<?> externalUserDefinition) {
+
+        return User.builder()
+                .username(externalUserDefinition.getUsername())
+                .email(externalUserDefinition.getEmail())
+                .enabled(authenticationConfig.isUserEnabledByDefault())
+                .created(new Date())
+                .defaultLocale(authenticationConfig.getDefaultLocale())
+                .role(externalUserDefinition.getRole())
+                .accountType(externalUserDefinition.getAccountType())
+                .externalID(formatExternalID(externalUserDefinition))
+                .build();
+    }
+
+    private String formatExternalID(ExternalUserDefinition<?> externalUserDefinition) {
+        return String.format(EXTERNAL_ID_TEMPLATE, externalUserDefinition.getAccountType().name().toLowerCase(), externalUserDefinition.getUserID());
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/AccountType.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/AccountType.java
@@ -10,5 +10,10 @@ public enum AccountType {
     /**
      * "Local" user account, the account is registered directly in the Leaflet system.
      */
-    LOCAL
+    LOCAL,
+
+    /**
+     * External user account, provided by GitHub.
+     */
+    GITHUB
 }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/DatabaseConstants.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/DatabaseConstants.java
@@ -21,6 +21,7 @@ public final class DatabaseConstants {
     static final String COLUMN_DEFAULT_LOCALE = "default_locale";
     static final String COLUMN_ACCOUNT_TYPE = "account_type";
     static final String COLUMN_DATE_LAST_LOGIN = "date_last_login";
+    static final String COLUMN_EXTERNAL_ID = "external_id";
 
     static final String UK_USER_EMAIL = "UK_USER_EMAIL";
 

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/Role.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/Role.java
@@ -13,6 +13,11 @@ public enum Role {
     USER,
 
     /**
+     * Role for visitors logged in via external identity providers.
+     */
+    EXTERNAL_USER,
+
+    /**
      * Blog editors.
      */
     EDITOR,

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/User.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/User.java
@@ -77,4 +77,8 @@ public class User {
 
     @Column(name = DatabaseConstants.COLUMN_IS_ENABLED)
     private boolean enabled;
+
+    @Column(name = DatabaseConstants.COLUMN_EXTERNAL_ID)
+    @Size(max = 255)
+    private String externalID;
 }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/internal/ExtendedUser.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/internal/ExtendedUser.java
@@ -4,8 +4,11 @@ import lombok.Builder;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Spring Security compatible {@link UserDetails} implementation containing extra user information.
@@ -14,7 +17,7 @@ import java.util.Collection;
  */
 @Data
 @Builder
-public class ExtendedUser implements UserDetails {
+public class ExtendedUser implements UserDetails, OAuth2User {
 
     private final String username;
     private final String password;
@@ -37,5 +40,15 @@ public class ExtendedUser implements UserDetails {
     @Override
     public boolean isCredentialsNonExpired() {
         return enabled;
+    }
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.emptyMap();
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/internal/ExternalUserDefinition.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/internal/ExternalUserDefinition.java
@@ -1,0 +1,23 @@
+package hu.psprog.leaflet.lags.core.domain.internal;
+
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.entity.Role;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Internal domain class for wrapping external user account data.
+ *
+ * @param <ID> type of the primary ID of the user
+ * @author Peter Smith
+ */
+@Data
+@Builder
+public class ExternalUserDefinition<ID> {
+
+    private final ID userID;
+    private final String email;
+    private final String username;
+    private final Role role = Role.EXTERNAL_USER;
+    private final AccountType accountType;
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/internal/GitHubEmailItem.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/internal/GitHubEmailItem.java
@@ -1,0 +1,15 @@
+package hu.psprog.leaflet.lags.core.domain.internal;
+
+import lombok.Data;
+
+/**
+ * Domain class for GitHub user emails API call responses.
+ *
+ * @author Peter Smith
+ */
+@Data
+public class GitHubEmailItem {
+
+    private boolean primary;
+    private String email;
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/exception/ExternalAuthenticationException.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/exception/ExternalAuthenticationException.java
@@ -1,0 +1,28 @@
+package hu.psprog.leaflet.lags.core.exception;
+
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Exception to be thrown where an error occurs during the sign-up process of an external user account.
+ *
+ * @author Peter Smith
+ */
+public class ExternalAuthenticationException extends AuthenticationException {
+
+    private final SignUpStatus signUpStatus;
+
+    public ExternalAuthenticationException(SignUpStatus signUpStatus, String message) {
+        super(message);
+        this.signUpStatus = signUpStatus;
+    }
+
+    /**
+     * Returns the assigned sign-up status.
+     *
+     * @return sign-up status as an item of the {@link SignUpStatus} enum
+     */
+    public SignUpStatus getSignUpStatus() {
+        return signUpStatus;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/security/ExternalSignUpAuthenticationFailureHandler.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/security/ExternalSignUpAuthenticationFailureHandler.java
@@ -1,0 +1,34 @@
+package hu.psprog.leaflet.lags.core.security;
+
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * {@link AuthenticationFailureHandler} implementation used to indicate an error in the sign-in process of an
+ * external user. The implementation simply redirects the user back to the main login page and passes a status value
+ * in query parameter, so the UI can show the proper error message.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class ExternalSignUpAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private static final String REDIRECT_PATH_TEMPLATE = "/login?ext_auth=%s";
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+
+        SignUpStatus signUpStatus = exception instanceof ExternalAuthenticationException
+                ? ((ExternalAuthenticationException) exception).getSignUpStatus()
+                : SignUpStatus.FAILURE;
+
+        response.sendRedirect(String.format(REDIRECT_PATH_TEMPLATE, signUpStatus.name()));
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/security/ReturnToAuthorizationAfterLogoutAuthenticationSuccessHandler.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/security/ReturnToAuthorizationAfterLogoutAuthenticationSuccessHandler.java
@@ -5,6 +5,7 @@ import org.springframework.security.web.authentication.SavedRequestAwareAuthenti
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ import java.util.Optional;
  *
  * @author Peter Smith
  */
+@Component
 public class ReturnToAuthorizationAfterLogoutAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
     private static final String LOGOUT_REF_PARAMETER = "logoutRef";

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/account/impl/ExternalAccountSignUpAccountRequestHandler.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/account/impl/ExternalAccountSignUpAccountRequestHandler.java
@@ -1,0 +1,74 @@
+package hu.psprog.leaflet.lags.core.service.account.impl;
+
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.persistence.dao.UserDAO;
+import hu.psprog.leaflet.lags.core.service.account.AccountRequestHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link AccountRequestHandler} implementation, that handles the sign-up/-in process of an external user account.
+ *
+ * The implementation does the following steps:
+ *  1) Checks whether a user account already exists with the given email address.
+ *  2) If so, verifies that the stored account type matches the one in the user definition. If that's the case, it means
+ *     that the account is already mirrored into the local user database and the sign-up process can be considered
+ *     successful. Otherwise, an account with the same email address exists from a different source, so the sign-up
+ *     process cannot be finished (indicated with {@link SignUpStatus#ADDRESS_IN_USE} status).
+ *  3) If no account exists with the given email address, sign-up process can move ahead with creating the new account
+ *     information and persisting it in the local user database as a mirror of the external account.
+ *
+ * @author Peter Smith
+ */
+@Component
+@Slf4j
+public class ExternalAccountSignUpAccountRequestHandler implements AccountRequestHandler<ExternalUserDefinition<?>, SignUpStatus> {
+
+    private final UserDAO userDAO;
+    private final ConversionService conversionService;
+
+    @Autowired
+    public ExternalAccountSignUpAccountRequestHandler(UserDAO userDAO, ConversionService conversionService) {
+        this.userDAO = userDAO;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public SignUpStatus processAccountRequest(ExternalUserDefinition<?> accountRequest) {
+
+        return userDAO.findByEmail(accountRequest.getEmail())
+                .map(user -> verifyExistingExternalUser(accountRequest, user))
+                .orElseGet(() -> saveNewExternalUser(accountRequest));
+    }
+
+    private SignUpStatus verifyExistingExternalUser(ExternalUserDefinition<?> accountRequest, User user) {
+
+        SignUpStatus signUpStatus = SignUpStatus.SUCCESS;
+        if (user.getAccountType() != accountRequest.getAccountType()) {
+            log.warn("A user account of type [{}] already exists for email address [{}] from external provider [{}]",
+                    user.getAccountType(), user.getEmail(), accountRequest.getAccountType());
+            signUpStatus = SignUpStatus.ADDRESS_IN_USE;
+        }
+
+        return signUpStatus;
+    }
+
+    private SignUpStatus saveNewExternalUser(ExternalUserDefinition<?> accountRequest) {
+
+        SignUpStatus signUpStatus = SignUpStatus.SUCCESS;
+        try {
+            User externalUser = conversionService.convert(accountRequest, User.class);
+            userDAO.save(externalUser);
+        } catch (Exception exception) {
+            log.error("Failed to save external user account [{}|email={}]",
+                    accountRequest.getAccountType(), accountRequest.getEmail(), exception);
+            signUpStatus = SignUpStatus.FAILURE;
+        }
+
+        return signUpStatus;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/account/impl/PasswordResetRequestAccountRequestHandler.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/account/impl/PasswordResetRequestAccountRequestHandler.java
@@ -1,6 +1,7 @@
 package hu.psprog.leaflet.lags.core.service.account.impl;
 
 import hu.psprog.leaflet.lags.core.config.AuthenticationConfig;
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
 import hu.psprog.leaflet.lags.core.domain.entity.User;
 import hu.psprog.leaflet.lags.core.domain.internal.SecurityConstants;
 import hu.psprog.leaflet.lags.core.domain.internal.TokenClaims;
@@ -49,7 +50,8 @@ public class PasswordResetRequestAccountRequestHandler implements AccountRequest
     @Override
     public Void processAccountRequest(PasswordResetRequestModel passwordResetRequestModel) {
 
-        Optional<User> userOptional = userDAO.findByEmail(passwordResetRequestModel.getEmail());
+        Optional<User> userOptional = userDAO.findByEmail(passwordResetRequestModel.getEmail())
+                .filter(user -> user.getAccountType() == AccountType.LOCAL);
 
         if (userOptional.isPresent()) {
             User user = userOptional.get();
@@ -59,7 +61,7 @@ public class PasswordResetRequestAccountRequestHandler implements AccountRequest
             sendPasswordResetRequestNotification(user, reclaimToken);
             log.info("Password reset request processed for user identified by ID={}", user.getId());
         } else {
-            log.warn("User account identified by email [{}] does not exist", passwordResetRequestModel.getEmail());
+            log.warn("User account identified by email [{}] does not exist or non-local", passwordResetRequestModel.getEmail());
         }
 
         return null;

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistry.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistry.java
@@ -28,6 +28,12 @@ public class StaticRoleToAuthorityMappingRegistry implements RoleToAuthorityMapp
             "write:users:own"
     };
 
+    private static final String[] EXTERNAL_USER_AUTHORITIES = {
+            "read:comments:own",
+            "read:users:own",
+            "write:comments:own"
+    };
+
     private static final String[] EDITOR_AUTHORITIES = Stream.concat(Stream.of(USER_AUTHORITIES), Stream.of(
             "read:categories",
             "read:comments",
@@ -50,6 +56,7 @@ public class StaticRoleToAuthorityMappingRegistry implements RoleToAuthorityMapp
 
     private static final Map<Role, List<GrantedAuthority>> ROLE_TO_AUTHORITY_LIST_MAP = Map.of(
             Role.USER, AuthorityUtils.createAuthorityList(USER_AUTHORITIES),
+            Role.EXTERNAL_USER, AuthorityUtils.createAuthorityList(EXTERNAL_USER_AUTHORITIES),
             Role.EDITOR, AuthorityUtils.createAuthorityList(EDITOR_AUTHORITIES),
             Role.ADMIN, AuthorityUtils.createAuthorityList(ADMIN_AUTHORITIES)
     );

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/AllLocalUserUserDetailsService.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/AllLocalUserUserDetailsService.java
@@ -1,0 +1,28 @@
+package hu.psprog.leaflet.lags.core.service.userdetails;
+
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.persistence.dao.UserDAO;
+import hu.psprog.leaflet.lags.core.service.registry.RoleToAuthorityMappingRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.function.Predicate;
+
+/**
+ * {@link LocalUserUserDetailsService} implementation handling all users, regardless their account type.
+ *
+ * @author Peter Smith
+ */
+@Service
+public class AllLocalUserUserDetailsService extends LocalUserUserDetailsService {
+
+    @Autowired
+    public AllLocalUserUserDetailsService(UserDAO userDAO, RoleToAuthorityMappingRegistry roleToAuthorityMappingRegistry) {
+        super(userDAO, roleToAuthorityMappingRegistry);
+    }
+
+    @Override
+    protected Predicate<User> userFilter() {
+        return user -> true;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/AutoRegisteringOAuth2UserService.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/AutoRegisteringOAuth2UserService.java
@@ -46,7 +46,7 @@ public class AutoRegisteringOAuth2UserService implements OAuth2UserService<OAuth
     @Autowired
     public AutoRegisteringOAuth2UserService(OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService,
                                             AccountRequestHandler<ExternalUserDefinition<?>, SignUpStatus> signUpAccountRequestHandler,
-                                            @Qualifier("localUserUserDetailsService") UserDetailsService userDetailsService,
+                                            @Qualifier("allLocalUserUserDetailsService") UserDetailsService userDetailsService,
                                             List<UserDataFactory<?>> userDataFactoryList) {
         this.defaultOAuth2UserService = defaultOAuth2UserService;
         this.signUpAccountRequestHandler = signUpAccountRequestHandler;

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/AutoRegisteringOAuth2UserService.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/AutoRegisteringOAuth2UserService.java
@@ -1,0 +1,73 @@
+package hu.psprog.leaflet.lags.core.service.userdetails;
+
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
+import hu.psprog.leaflet.lags.core.service.account.AccountRequestHandler;
+import hu.psprog.leaflet.lags.core.service.userdetails.external.UserDataFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Custom {@link OAuth2UserService} to handle mirroring the authenticated external user accounts into the local user
+ * database.
+ *
+ * The implementation does the following steps:
+ *  1) Calls the default {@link OAuth2UserService} implementation to handle collecting the basic account information.
+ *  2) Selects the proper {@link UserDataFactory} implementation based on the currently used OAuth identity provider.
+ *  3) Creates an {@link ExternalUserDefinition} object by calling the selected {@link UserDataFactory} implementation.
+ *  4) Passes the definition to the {@link AccountRequestHandler} implementation dealing with signing up external user accounts.
+ *  5) If the account is successfully signed up (or a returning user is acknowledged), then finally loads and returns the
+ *     assigned local user account.
+ *
+ * @author Peter Smith
+ */
+@Primary
+@Service
+public class AutoRegisteringOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService;
+    private final AccountRequestHandler<ExternalUserDefinition<?>, SignUpStatus> signUpAccountRequestHandler;
+    private final UserDetailsService userDetailsService;
+    private final Map<String, UserDataFactory<?>> userDataFactoryMap;
+
+    @Autowired
+    public AutoRegisteringOAuth2UserService(OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService,
+                                            AccountRequestHandler<ExternalUserDefinition<?>, SignUpStatus> signUpAccountRequestHandler,
+                                            @Qualifier("localUserUserDetailsService") UserDetailsService userDetailsService,
+                                            List<UserDataFactory<?>> userDataFactoryList) {
+        this.defaultOAuth2UserService = defaultOAuth2UserService;
+        this.signUpAccountRequestHandler = signUpAccountRequestHandler;
+        this.userDetailsService = userDetailsService;
+        this.userDataFactoryMap = userDataFactoryList.stream()
+                .collect(Collectors.toMap(UserDataFactory::forProvider, Function.identity()));
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = defaultOAuth2UserService.loadUser(userRequest);
+        ExternalUserDefinition<?> externalUserDefinition = userDataFactoryMap
+                .get(userRequest.getClientRegistration().getRegistrationId())
+                .createUserDefinition(userRequest, oAuth2User);
+
+        SignUpStatus signUpStatus = signUpAccountRequestHandler.processAccountRequest(externalUserDefinition);
+        if (signUpStatus != SignUpStatus.SUCCESS) {
+            throw new ExternalAuthenticationException(signUpStatus, "Failed to create local mirror for external account");
+        }
+
+        return (OAuth2User) userDetailsService.loadUserByUsername(externalUserDefinition.getEmail());
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/NonExternalLocalUserUserDetailsService.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/NonExternalLocalUserUserDetailsService.java
@@ -1,0 +1,30 @@
+package hu.psprog.leaflet.lags.core.service.userdetails;
+
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.persistence.dao.UserDAO;
+import hu.psprog.leaflet.lags.core.service.registry.RoleToAuthorityMappingRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.function.Predicate;
+
+/**
+ * {@link LocalUserUserDetailsService} implementation handling users only with local account type (excluding any account
+ * created via the registered OAuth providers).
+ *
+ * @author Peter Smith
+ */
+@Service
+public class NonExternalLocalUserUserDetailsService extends LocalUserUserDetailsService {
+
+    @Autowired
+    public NonExternalLocalUserUserDetailsService(UserDAO userDAO, RoleToAuthorityMappingRegistry roleToAuthorityMappingRegistry) {
+        super(userDAO, roleToAuthorityMappingRegistry);
+    }
+
+    @Override
+    protected Predicate<User> userFilter() {
+        return user -> user.getAccountType() == AccountType.LOCAL;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/UserDataFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/UserDataFactory.java
@@ -1,0 +1,34 @@
+package hu.psprog.leaflet.lags.core.service.userdetails.external;
+
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+/**
+ * Implementations of this interface should be able to create {@link ExternalUserDefinition} objects, that can be used
+ * to sign-up users coming from external providers (such as GitHub, Google, etc.).
+ *
+ * @param <ID> type of the primary ID of the users (passed to the {@link ExternalUserDefinition} object)
+ * @author Peter Smith
+ */
+public interface UserDataFactory<ID> {
+
+    /**
+     * Creates an {@link ExternalUserDefinition} object based on the {@link OAuth2UserRequest} (mainly needed to determine
+     * the OAuth identity provider registration name) and the authenticated {@link OAuth2User} object (in order for the
+     * factories to be able to collect the necessary user attributes).
+     *
+     * @param userRequest {@link OAuth2UserRequest} object
+     * @param oAuth2User {@link OAuth2User} object
+     * @return created user definition as {@link ExternalUserDefinition}
+     */
+    ExternalUserDefinition<ID> createUserDefinition(OAuth2UserRequest userRequest, OAuth2User oAuth2User);
+
+    /**
+     * Returns the name of the assigned OAuth identity provider. The returned name must match the OAuth provider registration
+     * name in the security configuration.
+     *
+     * @return name of the assigned OAuth identity provider
+     */
+    String forProvider();
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactory.java
@@ -1,0 +1,123 @@
+package hu.psprog.leaflet.lags.core.service.userdetails.external.impl;
+
+import hu.psprog.leaflet.bridge.client.BridgeClient;
+import hu.psprog.leaflet.bridge.client.domain.BridgeService;
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.exception.DefaultNonSuccessfulResponseException;
+import hu.psprog.leaflet.bridge.client.request.RESTRequest;
+import hu.psprog.leaflet.bridge.client.request.RequestMethod;
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
+import hu.psprog.leaflet.lags.core.service.userdetails.external.UserDataFactory;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import javax.ws.rs.core.GenericType;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * {@link UserDataFactory} implementation handling external user definition creation for users coming from GitHub.
+ *
+ * The implementation collects the following information:
+ *  - Account type will be {@link AccountType#GITHUB}.
+ *  - User ID (external) is collected from the "id" OAuth user attribute.
+ *  - Username is collected from the "name" OAuth user attribute.
+ *  - Email address is collected using GitHub's {@code /user/emails} API endpoint, by extracting the user's primary email address.
+ *
+ * @author Peter Smith
+ */
+@BridgeService(client = "github")
+@Slf4j
+public class GitHubUserDataFactory implements UserDataFactory<Long> {
+
+    private static final String PROVIDER_NAME = "github";
+    private static final String ATTRIBUTE_USER_ID = "id";
+    private static final String ATTRIBUTE_USERNAME = "name";
+
+    private static final GenericType<List<GitHubEmailItem>> GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE = new GenericType<>() {};
+    private static final String PATH_USER_EMAILS = "/user/emails";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String BEARER_TOKEN_TEMPLATE = "Bearer %s";
+
+    private final BridgeClient bridgeClient;
+
+    @Autowired
+    public GitHubUserDataFactory(BridgeClient bridgeClient) {
+        this.bridgeClient = bridgeClient;
+    }
+
+    @Override
+    public ExternalUserDefinition<Long> createUserDefinition(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+
+        return ExternalUserDefinition.<Long>builder()
+                .accountType(AccountType.GITHUB)
+                .userID(extractUserID(oAuth2User))
+                .username(extractUsername(oAuth2User))
+                .email(getPrimaryEmail(userRequest))
+                .build();
+    }
+
+    @Override
+    public String forProvider() {
+        return PROVIDER_NAME;
+    }
+
+    private Long extractUserID(OAuth2User oAuth2User) {
+
+        return Optional.ofNullable(oAuth2User.getAttribute(ATTRIBUTE_USER_ID))
+                .map(Integer.class::cast)
+                .map(Integer::longValue)
+                .orElse(0L);
+    }
+
+    private String extractUsername(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute(ATTRIBUTE_USERNAME);
+    }
+
+    private String getPrimaryEmail(OAuth2UserRequest userRequest) {
+
+        return retrieveEmailAddresses(userRequest)
+                .stream()
+                .filter(GitHubEmailItem::isPrimary)
+                .map(GitHubEmailItem::getEmail)
+                .findFirst()
+                .orElseThrow(supplyAuthenticationException());
+    }
+
+    private List<GitHubEmailItem> retrieveEmailAddresses(OAuth2UserRequest userRequest) {
+
+        try {
+            return bridgeClient.call(createEmailRetrievalRequest(userRequest), GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE);
+        } catch (DefaultNonSuccessfulResponseException | CommunicationFailureException exception) {
+            log.error("Could not contact GitHub API to retrieve the user's primary address address", exception);
+            throw supplyAuthenticationException().get();
+        }
+    }
+
+    private RESTRequest createEmailRetrievalRequest(OAuth2UserRequest userRequest) {
+
+        return RESTRequest.getBuilder()
+                .method(RequestMethod.GET)
+                .path(() -> PATH_USER_EMAILS)
+                .addHeaderParameter(HEADER_AUTHORIZATION, String.format(BEARER_TOKEN_TEMPLATE, userRequest.getAccessToken().getTokenValue()))
+                .build();
+    }
+
+    private Supplier<ExternalAuthenticationException> supplyAuthenticationException() {
+        return () -> new ExternalAuthenticationException(SignUpStatus.FAILURE, "Could not retrieve primary email address from the user's GitHub account");
+    }
+
+    @Data
+    static class GitHubEmailItem {
+
+        private boolean primary;
+        private String email;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactory.java
@@ -8,10 +8,10 @@ import hu.psprog.leaflet.bridge.client.request.RESTRequest;
 import hu.psprog.leaflet.bridge.client.request.RequestMethod;
 import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
 import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.internal.GitHubEmailItem;
 import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
 import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
 import hu.psprog.leaflet.lags.core.service.userdetails.external.UserDataFactory;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -112,12 +112,5 @@ public class GitHubUserDataFactory implements UserDataFactory<Long> {
 
     private Supplier<ExternalAuthenticationException> supplyAuthenticationException() {
         return () -> new ExternalAuthenticationException(SignUpStatus.FAILURE, "Could not retrieve primary email address from the user's GitHub account");
-    }
-
-    @Data
-    static class GitHubEmailItem {
-
-        private boolean primary;
-        private String email;
     }
 }

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/conversion/ExternalUserDefinitionToUserConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/conversion/ExternalUserDefinitionToUserConverterTest.java
@@ -1,0 +1,77 @@
+package hu.psprog.leaflet.lags.core.conversion;
+
+import hu.psprog.leaflet.lags.core.config.AuthenticationConfig;
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.entity.Role;
+import hu.psprog.leaflet.lags.core.domain.entity.SupportedLocale;
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link ExternalUserDefinitionToUserConverter}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class ExternalUserDefinitionToUserConverterTest {
+
+    private static final long USER_ID = 1234L;
+    private static final String USERNAME = "External User";
+    private static final String EMAIL = "externauser@dev.local";
+    private static final boolean USER_ENABLED_BY_DEFAULT = true;
+    private static final SupportedLocale DEFAULT_LOCALE = SupportedLocale.EN;
+    private static final ExternalUserDefinition<Long> EXTERNAL_USER_DEFINITION = prepareExternalUserDefinition();
+
+    @Mock
+    private AuthenticationConfig authenticationConfig;
+
+    @InjectMocks
+    private ExternalUserDefinitionToUserConverter externalUserDefinitionToUserConverter;
+
+    @Test
+    public void shouldConvertSignUpRequestToLocalUserObject() {
+
+        // given
+        given(authenticationConfig.isUserEnabledByDefault()).willReturn(USER_ENABLED_BY_DEFAULT);
+        given(authenticationConfig.getDefaultLocale()).willReturn(DEFAULT_LOCALE);
+
+        // when
+        User result = externalUserDefinitionToUserConverter.convert(EXTERNAL_USER_DEFINITION);
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result.getUsername(), equalTo(USERNAME));
+        assertThat(result.getEmail(), equalTo(EMAIL));
+        assertThat(result.isEnabled(), is(USER_ENABLED_BY_DEFAULT));
+        assertThat(result.getDefaultLocale(), equalTo(DEFAULT_LOCALE));
+        assertThat(result.getRole(), equalTo(Role.EXTERNAL_USER));
+        assertThat(result.getAccountType(), equalTo(AccountType.GITHUB));
+        assertThat(result.getExternalID(), equalTo("provider=github|ext_uid=1234"));
+        assertThat(System.currentTimeMillis() - result.getCreated().getTime() < 100, is(true));
+        assertThat(result.getLastLogin(), nullValue());
+        assertThat(result.getLastModified(), nullValue());
+        assertThat(result.getPassword(), nullValue());
+    }
+
+    private static ExternalUserDefinition<Long> prepareExternalUserDefinition() {
+
+        return ExternalUserDefinition.<Long>builder()
+                .username(USERNAME)
+                .email(EMAIL)
+                .accountType(AccountType.GITHUB)
+                .userID(USER_ID)
+                .build();
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/security/ExternalSignUpAuthenticationFailureHandlerTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/security/ExternalSignUpAuthenticationFailureHandlerTest.java
@@ -1,0 +1,61 @@
+package hu.psprog.leaflet.lags.core.security;
+
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link ExternalSignUpAuthenticationFailureHandler}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class ExternalSignUpAuthenticationFailureHandlerTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private ExternalSignUpAuthenticationFailureHandler externalSignUpAuthenticationFailureHandler;
+
+    @Test
+    public void shouldOnAuthenticationFailureSendRedirectionForExternalAuthenticationException() throws IOException {
+
+        // given
+        AuthenticationException exception = new ExternalAuthenticationException(SignUpStatus.ADDRESS_IN_USE, "Failure");
+
+        // when
+        externalSignUpAuthenticationFailureHandler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        verify(response).sendRedirect("/login?ext_auth=ADDRESS_IN_USE");
+    }
+
+    @Test
+    public void shouldOnAuthenticationFailureSendRedirectionForAnyOtherAuthenticationException() throws IOException {
+
+        // given
+        AuthenticationException exception = new OAuth2AuthenticationException("invalid_scope");
+
+        // when
+        externalSignUpAuthenticationFailureHandler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        verify(response).sendRedirect("/login?ext_auth=FAILURE");
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/account/impl/ExternalAccountSignUpAccountRequestHandlerTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/account/impl/ExternalAccountSignUpAccountRequestHandlerTest.java
@@ -1,0 +1,129 @@
+package hu.psprog.leaflet.lags.core.service.account.impl;
+
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.persistence.dao.UserDAO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.convert.ConversionService;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Unit tests for {@link ExternalAccountSignUpAccountRequestHandler}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class ExternalAccountSignUpAccountRequestHandlerTest {
+
+    private static final String EMAIL = "externaluser1@dev.local";
+    private static final ExternalUserDefinition<Long> EXTERNAL_USER_DEFINITION = prepareExternalUserDefinition();
+
+    @Mock
+    private UserDAO userDAO;
+
+    @Mock
+    private ConversionService conversionService;
+
+    @InjectMocks
+    private ExternalAccountSignUpAccountRequestHandler externalAccountSignUpAccountRequestHandler;
+
+    @Test
+    public void shouldProcessAccountRequestSuccessfullySaveNewExternalUser() {
+
+        // given
+        User externalUser = prepareUser(AccountType.GITHUB);
+
+        given(userDAO.findByEmail(EMAIL)).willReturn(Optional.empty());
+        given(conversionService.convert(EXTERNAL_USER_DEFINITION, User.class)).willReturn(externalUser);
+
+        // when
+        SignUpStatus result = externalAccountSignUpAccountRequestHandler.processAccountRequest(EXTERNAL_USER_DEFINITION);
+
+        // then
+        assertThat(result, equalTo(SignUpStatus.SUCCESS));
+
+        verify(userDAO).save(externalUser);
+    }
+
+    @Test
+    public void shouldProcessAccountRequestSuccessfullyVerifyExistingExternalUser() {
+
+        // given
+        User externalUser = prepareUser(AccountType.GITHUB);
+
+        given(userDAO.findByEmail(EMAIL)).willReturn(Optional.of(externalUser));
+
+        // when
+        SignUpStatus result = externalAccountSignUpAccountRequestHandler.processAccountRequest(EXTERNAL_USER_DEFINITION);
+
+        // then
+        assertThat(result, equalTo(SignUpStatus.SUCCESS));
+
+        verifyNoMoreInteractions(userDAO);
+        verifyNoInteractions(conversionService);
+    }
+
+    @Test
+    public void shouldProcessAccountRequestFailToSaveNewExternalUser() {
+
+        // given
+        User externalUser = prepareUser(AccountType.GITHUB);
+
+        given(userDAO.findByEmail(EMAIL)).willReturn(Optional.empty());
+        given(conversionService.convert(EXTERNAL_USER_DEFINITION, User.class)).willReturn(externalUser);
+        doThrow(RuntimeException.class).when(userDAO).save(externalUser);
+
+        // when
+        SignUpStatus result = externalAccountSignUpAccountRequestHandler.processAccountRequest(EXTERNAL_USER_DEFINITION);
+
+        // then
+        assertThat(result, equalTo(SignUpStatus.FAILURE));
+    }
+
+    @Test
+    public void shouldProcessAccountRequestFailToVerifyExistingExternalUser() {
+
+        // given
+        User externalUser = prepareUser(AccountType.LOCAL);
+
+        given(userDAO.findByEmail(EMAIL)).willReturn(Optional.of(externalUser));
+
+        // when
+        SignUpStatus result = externalAccountSignUpAccountRequestHandler.processAccountRequest(EXTERNAL_USER_DEFINITION);
+
+        // then
+        assertThat(result, equalTo(SignUpStatus.ADDRESS_IN_USE));
+    }
+
+    private static ExternalUserDefinition<Long> prepareExternalUserDefinition() {
+
+        return ExternalUserDefinition.<Long>builder()
+                .email(EMAIL)
+                .accountType(AccountType.GITHUB)
+                .build();
+    }
+
+    private User prepareUser(AccountType accountType) {
+
+        User user = new User();
+        user.setEmail(EMAIL);
+        user.setAccountType(accountType);
+
+        return user;
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/registry/impl/StaticRoleToAuthorityMappingRegistryTest.java
@@ -41,6 +41,20 @@ class StaticRoleToAuthorityMappingRegistryTest {
     }
 
     @Test
+    public void shouldGetAuthoritiesForRoleReturnExternalUserAuthorities() {
+
+        // when
+        List<GrantedAuthority> result = staticRoleToAuthorityMappingRegistry.getAuthoritiesForRole(Role.EXTERNAL_USER);
+
+        // then
+        assertThat(result, equalTo(AuthorityUtils.createAuthorityList(
+                "read:comments:own",
+                "read:users:own",
+                "write:comments:own"
+        )));
+    }
+
+    @Test
     public void shouldGetAuthoritiesForRoleReturnEditorAuthorities() {
 
         // when

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/AllLocalUserUserDetailsServiceTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/AllLocalUserUserDetailsServiceTest.java
@@ -1,0 +1,129 @@
+package hu.psprog.leaflet.lags.core.service.userdetails;
+
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.entity.Role;
+import hu.psprog.leaflet.lags.core.domain.entity.User;
+import hu.psprog.leaflet.lags.core.domain.internal.ExtendedUser;
+import hu.psprog.leaflet.lags.core.persistence.dao.UserDAO;
+import hu.psprog.leaflet.lags.core.service.registry.RoleToAuthorityMappingRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link AllLocalUserUserDetailsService}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class AllLocalUserUserDetailsServiceTest {
+
+    private static final String LOCAL_USER_EMAIL = "admin@dev.local";
+    private static final String EXTERNAL_USER_EMAIL = "externaluser1@dev.local";
+    private static final User LOCAL_USER = prepareUser(AccountType.LOCAL);
+    private static final User EXTERNAL_USER = prepareUser(AccountType.GITHUB);
+    private static final List<GrantedAuthority> AUTHORITIES = AuthorityUtils.createAuthorityList("read:all", "write:all");
+    private static final ExtendedUser EXPECTED_EXTENDED_LOCAL_USER = prepareExpectedExtendedUser(LOCAL_USER);
+    private static final ExtendedUser EXPECTED_EXTENDED_EXTERNAL_USER = prepareExpectedExtendedUser(EXTERNAL_USER);
+
+    @Mock
+    private UserDAO userDAO;
+
+    @Mock
+    private RoleToAuthorityMappingRegistry roleToAuthorityMappingRegistry;
+
+    @InjectMocks
+    private AllLocalUserUserDetailsService allLocalUserUserDetailsService;
+
+    @Test
+    public void shouldLoadUserByUsernameSuccessfullyLoadLocalUser() {
+
+        // given
+        given(userDAO.findByEmail(LOCAL_USER_EMAIL)).willReturn(Optional.of(LOCAL_USER));
+        given(roleToAuthorityMappingRegistry.getAuthoritiesForRole(Role.ADMIN)).willReturn(AUTHORITIES);
+
+        // when
+        UserDetails result = allLocalUserUserDetailsService.loadUserByUsername(LOCAL_USER_EMAIL);
+
+        // then
+        assertThat(result instanceof ExtendedUser, is(true));
+        assertThat(result, equalTo(EXPECTED_EXTENDED_LOCAL_USER));
+    }
+
+    @Test
+    public void shouldLoadUserByUsernameSuccessfullyLoadExternalUser() {
+
+        // given
+        given(userDAO.findByEmail(EXTERNAL_USER_EMAIL)).willReturn(Optional.of(EXTERNAL_USER));
+        given(roleToAuthorityMappingRegistry.getAuthoritiesForRole(Role.USER)).willReturn(AUTHORITIES);
+
+        // when
+        UserDetails result = allLocalUserUserDetailsService.loadUserByUsername(EXTERNAL_USER_EMAIL);
+
+        // then
+        assertThat(result instanceof ExtendedUser, is(true));
+        assertThat(result, equalTo(EXPECTED_EXTENDED_EXTERNAL_USER));
+    }
+
+    @Test
+    public void shouldLoadUserByUsernameThrowExceptionOnMissingUser() {
+
+        // given
+        given(userDAO.findByEmail(LOCAL_USER_EMAIL)).willReturn(Optional.empty());
+
+        // when
+        Throwable result = assertThrows(UsernameNotFoundException.class, () -> allLocalUserUserDetailsService.loadUserByUsername(LOCAL_USER_EMAIL));
+
+        // then
+        // exception expected
+        assertThat(result.getMessage(), equalTo("User identified by email address [admin@dev.local] not found"));
+    }
+
+    private static User prepareUser(AccountType accountType) {
+
+        User user = new User();
+        user.setPassword("password1" + accountType);
+        user.setUsername("user1" + accountType);
+        user.setEnabled(true);
+        user.setAccountType(accountType);
+        if (accountType == AccountType.LOCAL) {
+            user.setEmail(LOCAL_USER_EMAIL);
+            user.setId(1234L);
+            user.setRole(Role.ADMIN);
+        } else {
+            user.setEmail(EXTERNAL_USER_EMAIL);
+            user.setId(5678L);
+            user.setRole(Role.USER);
+        }
+
+        return user;
+    }
+
+    private static ExtendedUser prepareExpectedExtendedUser(User sourceUser) {
+
+        return ExtendedUser.builder()
+                .username(sourceUser.getEmail())
+                .password(sourceUser.getPassword())
+                .name(sourceUser.getUsername())
+                .id(sourceUser.getId())
+                .enabled(sourceUser.isEnabled())
+                .role(sourceUser.getRole().toString())
+                .authorities(AUTHORITIES)
+                .build();
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/AutoRegisteringOAuth2UserServiceTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/AutoRegisteringOAuth2UserServiceTest.java
@@ -1,0 +1,153 @@
+package hu.psprog.leaflet.lags.core.service.userdetails;
+
+import hu.psprog.leaflet.lags.core.domain.internal.ExtendedUser;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.response.SignUpStatus;
+import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
+import hu.psprog.leaflet.lags.core.service.account.AccountRequestHandler;
+import hu.psprog.leaflet.lags.core.service.userdetails.external.UserDataFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link AutoRegisteringOAuth2UserService}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class AutoRegisteringOAuth2UserServiceTest {
+
+    private static final String FIRST_REGISTRATION_ID = "first";
+    private static final String SECOND_REGISTRATION_ID = "second";
+    private static final String EXTERNAL_USER_EMAIL = "externaluser1@dev.local";
+
+    @Mock
+    private OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService;
+
+    @Mock
+    private AccountRequestHandler<ExternalUserDefinition<?>, SignUpStatus> signUpAccountRequestHandler;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private UserDataFactory<Long> firstUserDataFactory;
+
+    @Mock
+    private UserDataFactory<Long> secondUserDataFactory;
+
+    @Mock
+    private OAuth2User oAuth2User;
+
+    @Mock
+    private ExternalUserDefinition<Long> externalUserDefinition;
+
+    @Mock
+    private ExtendedUser localOAuth2User;
+
+    private AutoRegisteringOAuth2UserService autoRegisteringOAuth2UserService;
+
+    @BeforeEach
+    public void setup() {
+
+        given(firstUserDataFactory.forProvider()).willReturn(FIRST_REGISTRATION_ID);
+        given(secondUserDataFactory.forProvider()).willReturn(SECOND_REGISTRATION_ID);
+
+        autoRegisteringOAuth2UserService = new AutoRegisteringOAuth2UserService(defaultOAuth2UserService, signUpAccountRequestHandler,
+                userDetailsService, List.of(firstUserDataFactory, secondUserDataFactory));
+    }
+
+    @Test
+    public void shouldLoadUserSuccessfullyProcessExternalUserUsingFirstUserDataFactory() {
+
+        // given
+        OAuth2UserRequest userRequest = prepareUserRequest(FIRST_REGISTRATION_ID);
+
+        given(defaultOAuth2UserService.loadUser(userRequest)).willReturn(oAuth2User);
+        given(firstUserDataFactory.createUserDefinition(userRequest, oAuth2User)).willReturn(externalUserDefinition);
+        given(signUpAccountRequestHandler.processAccountRequest(externalUserDefinition)).willReturn(SignUpStatus.SUCCESS);
+        given(externalUserDefinition.getEmail()).willReturn(EXTERNAL_USER_EMAIL);
+        given(userDetailsService.loadUserByUsername(EXTERNAL_USER_EMAIL)).willReturn(localOAuth2User);
+
+        // when
+        OAuth2User result = autoRegisteringOAuth2UserService.loadUser(userRequest);
+
+        // then
+        assertThat(result, equalTo(localOAuth2User));
+    }
+
+    @Test
+    public void shouldLoadUserSuccessfullyProcessExternalUserUsingSecondUserDataFactory() {
+
+        // given
+        OAuth2UserRequest userRequest = prepareUserRequest(SECOND_REGISTRATION_ID);
+
+        given(defaultOAuth2UserService.loadUser(userRequest)).willReturn(oAuth2User);
+        given(secondUserDataFactory.createUserDefinition(userRequest, oAuth2User)).willReturn(externalUserDefinition);
+        given(signUpAccountRequestHandler.processAccountRequest(externalUserDefinition)).willReturn(SignUpStatus.SUCCESS);
+        given(externalUserDefinition.getEmail()).willReturn(EXTERNAL_USER_EMAIL);
+        given(userDetailsService.loadUserByUsername(EXTERNAL_USER_EMAIL)).willReturn(localOAuth2User);
+
+        // when
+        OAuth2User result = autoRegisteringOAuth2UserService.loadUser(userRequest);
+
+        // then
+        assertThat(result, equalTo(localOAuth2User));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SignUpStatus.class, names = "SUCCESS", mode = EnumSource.Mode.EXCLUDE)
+    public void shouldLoadUserFailWithExceptionOnNonSuccessfulAccountRequestProcessing(SignUpStatus invalidSignUpStatus) {
+
+        // given
+        OAuth2UserRequest userRequest = prepareUserRequest(SECOND_REGISTRATION_ID);
+
+        given(defaultOAuth2UserService.loadUser(userRequest)).willReturn(oAuth2User);
+        given(secondUserDataFactory.createUserDefinition(userRequest, oAuth2User)).willReturn(externalUserDefinition);
+        given(signUpAccountRequestHandler.processAccountRequest(externalUserDefinition)).willReturn(invalidSignUpStatus);
+
+        // when
+        ExternalAuthenticationException exception = assertThrows(ExternalAuthenticationException.class, () -> autoRegisteringOAuth2UserService.loadUser(userRequest));
+
+        // then
+        // exception expected
+        assertThat(exception.getMessage(), equalTo("Failed to create local mirror for external account"));
+        assertThat(exception.getSignUpStatus(), equalTo(invalidSignUpStatus));
+    }
+
+    private OAuth2UserRequest prepareUserRequest(String registrationID) {
+
+        ClientRegistration clientRegistration = ClientRegistration
+                .withRegistrationId(registrationID)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .clientId("client-id-1")
+                .tokenUri("http://localhost")
+                .build();
+
+        OAuth2AccessToken oAuth2AccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "token1",
+                Instant.now(), Instant.now().plusSeconds(10L));
+
+        return new OAuth2UserRequest(clientRegistration, oAuth2AccessToken, Collections.emptyMap());
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactoryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactoryTest.java
@@ -1,0 +1,185 @@
+package hu.psprog.leaflet.lags.core.service.userdetails.external.impl;
+
+import hu.psprog.leaflet.bridge.client.BridgeClient;
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.exception.ForbiddenOperationException;
+import hu.psprog.leaflet.bridge.client.request.RESTRequest;
+import hu.psprog.leaflet.bridge.client.request.RequestMethod;
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.domain.internal.GitHubEmailItem;
+import hu.psprog.leaflet.lags.core.exception.ExternalAuthenticationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import javax.ws.rs.core.GenericType;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+
+/**
+ * Unit tests for {@link GitHubUserDataFactory}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class GitHubUserDataFactoryTest {
+
+    private static final int USER_ID = 1122;
+    private static final String USERNAME = "External User";
+    private static final String EMAIL = "externaluser1-2@dev.local";
+    private static final String REGISTRATION_ID = "github";
+
+    private static final OAuth2UserRequest OAUTH_USER_REQUEST = prepareUserRequest();
+    private static final OAuth2User OAUTH_USER = prepareOAuth2User();
+    private static final ExternalUserDefinition<Long> EXPECTED_EXTERNAL_USER_DEFINITION = prepareExternalUserDefinition();
+
+    private static final GenericType<List<GitHubEmailItem>> GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE = new GenericType<>() {};
+    private static final List<GitHubEmailItem> GITHUB_EMAIL_ITEMS = prepareGitHubEmailResponse(true);
+    private static final List<GitHubEmailItem> GITHUB_EMAIL_ITEMS_WITHOUT_PRIMARY = prepareGitHubEmailResponse(false);
+
+    @Mock
+    private BridgeClient bridgeClient;
+
+    @Captor
+    private ArgumentCaptor<RESTRequest> restRequestCaptor;
+
+    @InjectMocks
+    private GitHubUserDataFactory gitHubUserDataFactory;
+
+    @Test
+    public void shouldCreateUserDefinitionProcessRequestSuccessfully() throws CommunicationFailureException {
+
+        // given
+        given(bridgeClient.call(restRequestCaptor.capture(), eq(GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE))).willReturn(GITHUB_EMAIL_ITEMS);
+
+        // when
+        ExternalUserDefinition<Long> result = gitHubUserDataFactory.createUserDefinition(OAUTH_USER_REQUEST, OAUTH_USER);
+
+        // then
+        assertThat(result, equalTo(EXPECTED_EXTERNAL_USER_DEFINITION));
+        assertRESTRequest(restRequestCaptor.getValue());
+    }
+
+    @Test
+    public void shouldCreateUserDefinitionFailForExternalUserNotHavingPrimaryEmailAddress() throws CommunicationFailureException {
+
+        // given
+        given(bridgeClient.call(any(), eq(GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE))).willReturn(GITHUB_EMAIL_ITEMS_WITHOUT_PRIMARY);
+
+        // when
+        assertThrows(ExternalAuthenticationException.class, () -> gitHubUserDataFactory.createUserDefinition(OAUTH_USER_REQUEST, OAUTH_USER));
+
+        // then
+        // exception expected
+    }
+
+    @Test
+    public void shouldCreateUserDefinitionFailWhenContactGitHubAPIFails() throws CommunicationFailureException {
+
+        // given
+        doThrow(ForbiddenOperationException.class).when(bridgeClient).call(any(), eq(GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE));
+
+        // when
+        assertThrows(ExternalAuthenticationException.class, () -> gitHubUserDataFactory.createUserDefinition(OAUTH_USER_REQUEST, OAUTH_USER));
+
+        // then
+        // exception expected
+    }
+
+    @Test
+    public void shouldForProviderReturnGitHub() {
+
+        // when
+        String result = gitHubUserDataFactory.forProvider();
+
+        // then
+        assertThat(result, equalTo(REGISTRATION_ID));
+    }
+
+    private void assertRESTRequest(RESTRequest restRequest) {
+
+        assertThat(restRequest.getMethod(), equalTo(RequestMethod.GET));
+        assertThat(restRequest.getPath().getURI(), equalTo("/user/emails"));
+        assertThat(restRequest.getHeaderParameters().size(), equalTo(1));
+        assertThat(restRequest.getHeaderParameters().get("Authorization"), equalTo("Bearer token1"));
+
+        assertThat(restRequest.getRequestBody(), nullValue());
+        assertThat(restRequest.getPathParameters().isEmpty(), is(true));
+        assertThat(restRequest.getRequestParameters().isEmpty(), is(true));
+        assertThat(restRequest.isAuthenticationRequired(), is(false));
+    }
+
+    private static OAuth2UserRequest prepareUserRequest() {
+
+        ClientRegistration clientRegistration = ClientRegistration
+                .withRegistrationId(REGISTRATION_ID)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .clientId("client-id-1")
+                .tokenUri("http://localhost")
+                .build();
+
+        OAuth2AccessToken oAuth2AccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "token1",
+                Instant.now(), Instant.now().plusSeconds(10L));
+
+        return new OAuth2UserRequest(clientRegistration, oAuth2AccessToken, Collections.emptyMap());
+    }
+
+    private static OAuth2User prepareOAuth2User() {
+
+        return new DefaultOAuth2User(Collections.emptyList(), Map.of(
+                "id", USER_ID,
+                "name", USERNAME
+        ), "name");
+    }
+
+    private static List<GitHubEmailItem> prepareGitHubEmailResponse(boolean includePrimary) {
+
+        return List.of(
+                prepareGitHubEmailItem("externaluser1-1@dev.local", false),
+                prepareGitHubEmailItem(EMAIL, includePrimary),
+                prepareGitHubEmailItem("externaluser1-3@dev.local", false)
+        );
+    }
+
+    private static ExternalUserDefinition<Long> prepareExternalUserDefinition() {
+
+        return ExternalUserDefinition.<Long>builder()
+                .accountType(AccountType.GITHUB)
+                .userID((long) USER_ID)
+                .username(USERNAME)
+                .email(EMAIL)
+                .build();
+    }
+
+    private static GitHubEmailItem prepareGitHubEmailItem(String email, boolean primary) {
+
+        GitHubEmailItem emailItem = new GitHubEmailItem();
+        emailItem.setEmail(email);
+        emailItem.setPrimary(primary);
+
+        return emailItem;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-access-gateway-service</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-dev</version>
+    <version>1.1.0-dev</version>
 
     <modules>
         <module>core</module>
@@ -25,7 +25,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>2.0-r2208.1</version>
+        <version>2.0-r2208.2</version>
     </parent>
 
     <properties>
@@ -52,8 +52,8 @@
         <docker.skip>true</docker.skip>
 
         <!-- test dependency versions -->
-        <cucumber-java.version>7.3.3</cucumber-java.version>
-        <junit-platform-suite.version>1.8.2</junit-platform-suite.version>
+        <cucumber-java.version>7.6.0</cucumber-java.version>
+        <junit-platform-suite.version>1.9.0</junit-platform-suite.version>
 
     </properties>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.0-dev</version>
+        <version>1.1.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/web/src/main/resources/webapp/templates/views/login.html
+++ b/web/src/main/resources/webapp/templates/views/login.html
@@ -70,6 +70,33 @@
 					new bootstrap.Modal(document.getElementById('pwResetSuccessfulModal'), {}).toggle();
                 </script>
             </th:block>
+
+            <th:block th:if="${param.ext_auth != null}">
+                <div class="modal fade show" id="signUpErrorModal" tabindex="-1" aria-labelledby="signUpErrorModalLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="signUpErrorModalLabel" th:text="#{flash.signin.failure}">Sign-in failed</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <th:block th:if="${#strings.equals(param.ext_auth, 'ADDRESS_IN_USE')}" th:text="#{flash.signup.ext.failure.explanation.address_in_use}">
+                                    address_in_use
+                                </th:block>
+                                <th:block th:if="${#strings.equals(param.ext_auth, 'FAILURE')}" th:text="#{flash.signup.ext.failure.explanation.unknown}">
+                                    unknown_error
+                                </th:block>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <script>
+                    new bootstrap.Modal(document.getElementById('signUpErrorModal'), {}).toggle();
+                </script>
+            </th:block>
         </th:block>
 
         <th:block layout:fragment="content">
@@ -93,9 +120,8 @@
                             <button type="submit" class="btn btn-primary w-100 align-middle">
                                 <span th:text="#{form.signin.label.send}">Sign In</span> <i class="fas fa-sign-in-alt"></i>
                             </button>
-                            <!-- TODO revert after integration with external authorizers is implemented -->
+                            <a class="btn btn-dark mx-2" th:href="@{/oauth2/authorization/github}"><i class="fab fa-github"></i></a>
                             <!--
-                            <a class="btn btn-dark mx-2"><i class="fab fa-github"></i></a>
                             <a class="btn btn-danger"><i class="fab fa-google"></i></a>
                             -->
                         </div>


### PR DESCRIPTION
 - Enabled and configured OAuth login (also refactored security configuration to move away from the deprecated way of configuration)
 - Implemented support for GitHub based external authentication
 - Bumped application version to 1.1.0-dev
 - Fixed role to authority mapping (added mapping for EXTERNAL_USER role)
 - Separated LocalUserUserDetailsService for local account and external provider sign-in handling
 - Added filtering in password reset flow to reject password reset requests on external accounts
 - Aligned existing unit tests, added new ones
 - Added new acceptance test cases for GitHub account based external authentication