### PR TITLE
LFLT-494 Add 3rd party login possibility to LAGS with Google account

### DIFF
--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stepdefs/AuthenticationStepDefinition.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stepdefs/AuthenticationStepDefinition.java
@@ -75,13 +75,13 @@ public class AuthenticationStepDefinition implements En {
         When("^the user signs out$",
                 () -> ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestSignOut()));
 
-        When("^the user requests sign-in via (GitHub)$", (String provider) -> {
+        When("^the user requests sign-in via (GitHub|Google)$", (String provider) -> {
 
             ExternalAuthenticationMock.Provider resolvedProvider = ExternalAuthenticationMock.Provider.valueOf(provider.toUpperCase());
             ThreadLocalDataRegistry.putResponseEntity(lagsClient.requestExternalLogin(resolvedProvider));
         });
 
-        When("^the user authorizes access on (GitHub)$", (String provider) -> {
+        When("^the user authorizes access on (GitHub|Google)$", (String provider) -> {
 
             ExternalAuthenticationMock.Provider resolvedProvider = ExternalAuthenticationMock.Provider.valueOf(provider.toUpperCase());
             externalAuthenticationMock.registerProviderMock(resolvedProvider);
@@ -89,7 +89,7 @@ public class AuthenticationStepDefinition implements En {
             externalAuthenticationMock.resetProviderMock();
         });
 
-        When("^the user rejects access on (GitHub)$", (String provider) -> {
+        When("^the user rejects access on (GitHub|Google)$", (String provider) -> {
 
             ExternalAuthenticationMock.Provider resolvedProvider = ExternalAuthenticationMock.Provider.valueOf(provider.toUpperCase());
             externalAuthenticationMock.registerProviderMock(resolvedProvider);

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stub/ExternalAuthenticationMock.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stub/ExternalAuthenticationMock.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -92,8 +93,9 @@ public class ExternalAuthenticationMock {
         givenThat(get(userInfoEndpoint)
                 .willReturn(jsonResponse(Map.of(
                         "name", EXTERNAL_USER_NAME,
-                        "sub", EXTERNAL_USER_ID,
-                        "id", EXTERNAL_USER_ID
+                        "sub", String.valueOf(EXTERNAL_USER_ID),
+                        "id", EXTERNAL_USER_ID,
+                        "email", ThreadLocalDataRegistry.get(TestConstants.Attribute.EMAIL)
                 ), 200)));
     }
 
@@ -117,7 +119,8 @@ public class ExternalAuthenticationMock {
 
     public enum Provider {
 
-        GITHUB("/githubmock/token", "/githubmock/userinfo", List.of(ExternalAuthenticationMock::registerGitHubEmailsEndpoint));
+        GITHUB("/githubmock/token", "/githubmock/userinfo", List.of(ExternalAuthenticationMock::registerGitHubEmailsEndpoint)),
+        GOOGLE("/googlemock/token", "/googlemock/userinfo", Collections.emptyList());
 
         private final String tokenEndpoint;
         private final String userinfoEndpoint;

--- a/acceptance/src/test/resources/application-acceptance.yml
+++ b/acceptance/src/test/resources/application-acceptance.yml
@@ -35,10 +35,19 @@ spring:
             scope:
               - read:user
               - user:email
+          google:
+            client-id: test-client-2
+            client-secret: client-secret-2
+            scope:
+              - profile
+              - email
         provider:
           github:
             token-uri: http://localhost:9290/githubmock/token
             user-info-uri: http://localhost:9290/githubmock/userinfo
+          google:
+            token-uri: http://localhost:9290/googlemock/token
+            user-info-uri: http://localhost:9290/googlemock/userinfo
 
 logging:
   pattern:

--- a/acceptance/src/test/resources/data.sql
+++ b/acceptance/src/test/resources/data.sql
@@ -13,4 +13,5 @@ values
     (3, @CREATED_DATE, true, 'EN', 'test-editor-2@ac-leaflet.local', 'EDITOR', 'Test Editor 2', @TEST_PW, 'LOCAL'),
     (4, @CREATED_DATE, true, 'HU', 'test-editor-3@ac-leaflet.local', 'EDITOR', 'Test Editor 3', @TEST_PW, 'LOCAL'),
     (5, @CREATED_DATE, true, 'HU', 'test-editor-pwgrant@ac-leaflet.local', 'EDITOR', 'Test Editor PW Grant', @TEST_PW, 'LOCAL'),
-    (6, @CREATED_DATE, true, 'HU', 'test-user-github@ac-leaflet.local', 'EXTERNAL_USER', 'Test External User GitHub', null, 'GITHUB');
+    (6, @CREATED_DATE, true, 'HU', 'test-user-github@ac-leaflet.local', 'EXTERNAL_USER', 'Test External User GitHub', null, 'GITHUB'),
+    (7, @CREATED_DATE, true, 'HU', 'test-user-google@ac-leaflet.local', 'EXTERNAL_USER', 'Test External User Google', null, 'GOOGLE');

--- a/acceptance/src/test/resources/features/external_authentication.feature
+++ b/acceptance/src/test/resources/features/external_authentication.feature
@@ -26,13 +26,49 @@ Feature: External provider based user sign-in flow tests
       And the external user is logged in with the email address test-user-github@ac-leaflet.local
       And the external user has the scopes read:comments:own read:users:own write:comments:own
 
+  @PositiveScenario
+  Scenario: Successfully signing-in with a Google account for the first time
+
+    Given the external user uses the email address googleuser1@dev.local
+
+     When the user requests sign-in via Google
+      And the user authorizes access on Google
+      And the user is returned to the authorization page
+
+     Then the external user is logged in as Test User
+      And the external user is logged in with the email address googleuser1@dev.local
+      And the external user has the scopes read:comments:own read:users:own write:comments:own
+
+  @PositiveScenario
+  Scenario: Successfully returning with a Google account
+
+    Given the external user uses the email address test-user-google@ac-leaflet.local
+
+     When the user requests sign-in via Google
+      And the user authorizes access on Google
+      And the user is returned to the authorization page
+
+     Then the external user is logged in as Test External User Google
+      And the external user is logged in with the email address test-user-google@ac-leaflet.local
+      And the external user has the scopes read:comments:own read:users:own write:comments:own
+
   @NegativeScenario
-  Scenario: Sign-up is not possible via external provider with an already used email address from a different source
+  Scenario: Sign-up is not possible via external provider (GitHub) with an already used email address from a different source
 
     Given the external user uses the email address test-user-1@ac-leaflet.local
 
      When the user requests sign-in via GitHub
       And the user authorizes access on GitHub
+
+     Then the user is redirected to /login?ext_auth=ADDRESS_IN_USE
+
+  @NegativeScenario
+  Scenario: Sign-up is not possible via external provider (Google) with an already used email address from a different source
+
+    Given the external user uses the email address test-user-1@ac-leaflet.local
+
+     When the user requests sign-in via Google
+      And the user authorizes access on Google
 
      Then the user is redirected to /login?ext_auth=ADDRESS_IN_USE
 
@@ -43,5 +79,15 @@ Feature: External provider based user sign-in flow tests
 
      When the user requests sign-in via GitHub
       And the user rejects access on GitHub
+
+     Then the user is redirected to /login?ext_auth=FAILURE
+
+  @NegativeScenario
+  Scenario: User rejects access on Google
+
+    Given the external user uses the email address googleuser1@dev.local
+
+     When the user requests sign-in via Google
+      And the user rejects access on Google
 
      Then the user is redirected to /login?ext_auth=FAILURE

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/AccountType.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/domain/entity/AccountType.java
@@ -15,5 +15,10 @@ public enum AccountType {
     /**
      * External user account, provided by GitHub.
      */
-    GITHUB
+    GITHUB,
+
+    /**
+     * External user account, provided by Google.
+     */
+    GOOGLE
 }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GoogleUserDataFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GoogleUserDataFactory.java
@@ -1,0 +1,57 @@
+package hu.psprog.leaflet.lags.core.service.userdetails.external.impl;
+
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import hu.psprog.leaflet.lags.core.service.userdetails.external.UserDataFactory;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link UserDataFactory} implementation handling external user definition creation for users coming from Google.
+ *
+ * The implementation collects the following information:
+ *  - Account type will be {@link AccountType#GOOGLE}.
+ *  - User ID (external) is collected from the "sub" OAuth user attribute.
+ *  - Username is collected from the "name" OAuth user attribute.
+ *  - Email address is collected from the "email" OAuth user attribute.
+ *
+ *
+ * @author Peter Smith
+ */
+@Component
+public class GoogleUserDataFactory implements UserDataFactory<String> {
+
+    private static final String PROVIDER_NAME = "google";
+    private static final String ATTRIBUTE_USER_ID = "sub";
+    private static final String ATTRIBUTE_USERNAME = "name";
+    private static final String ATTRIBUTE_EMAIL = "email";
+
+    @Override
+    public ExternalUserDefinition<String> createUserDefinition(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+
+        return ExternalUserDefinition.<String>builder()
+                .accountType(AccountType.GOOGLE)
+                .userID(extractUserID(oAuth2User))
+                .username(extractUsername(oAuth2User))
+                .email(extractEmail(oAuth2User))
+                .build();
+    }
+
+    @Override
+    public String forProvider() {
+        return PROVIDER_NAME;
+    }
+
+    private String extractUserID(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute(ATTRIBUTE_USER_ID);
+    }
+
+    private String extractUsername(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute(ATTRIBUTE_USERNAME);
+    }
+
+    private String extractEmail(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute(ATTRIBUTE_EMAIL);
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GoogleUserDataFactoryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GoogleUserDataFactoryTest.java
@@ -1,0 +1,75 @@
+package hu.psprog.leaflet.lags.core.service.userdetails.external.impl;
+
+import hu.psprog.leaflet.lags.core.domain.entity.AccountType;
+import hu.psprog.leaflet.lags.core.domain.internal.ExternalUserDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Unit tests for {@link GoogleUserDataFactory}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class GoogleUserDataFactoryTest {
+
+    private static final String USER_ID = "997744";
+    private static final String USERNAME = "External User";
+    private static final String EMAIL = "externaluser1-2@dev.local";
+    private static final String REGISTRATION_ID = "google";
+
+    private static final OAuth2User OAUTH_USER = prepareOAuth2User();
+    private static final ExternalUserDefinition<String> EXPECTED_EXTERNAL_USER_DEFINITION = prepareExternalUserDefinition();
+
+    @InjectMocks
+    private GoogleUserDataFactory googleUserDataFactory;
+
+    @Test
+    public void shouldCreateUserDefinitionProcessRequestSuccessfully() {
+
+        // when
+        ExternalUserDefinition<String> result = googleUserDataFactory.createUserDefinition(null, OAUTH_USER);
+
+        // then
+        assertThat(result, equalTo(EXPECTED_EXTERNAL_USER_DEFINITION));
+    }
+
+    @Test
+    public void shouldForProviderReturnGoogle() {
+
+        // when
+        String result = googleUserDataFactory.forProvider();
+
+        // then
+        assertThat(result, equalTo(REGISTRATION_ID));
+    }
+
+    private static OAuth2User prepareOAuth2User() {
+
+        return new DefaultOAuth2User(Collections.emptyList(), Map.of(
+                "sub", USER_ID,
+                "name", USERNAME,
+                "email", EMAIL
+        ), "sub");
+    }
+
+    private static ExternalUserDefinition<String> prepareExternalUserDefinition() {
+
+        return ExternalUserDefinition.<String>builder()
+                .accountType(AccountType.GOOGLE)
+                .userID(USER_ID)
+                .username(USERNAME)
+                .email(EMAIL)
+                .build();
+    }
+}

--- a/web/src/main/resources/webapp/templates/views/login.html
+++ b/web/src/main/resources/webapp/templates/views/login.html
@@ -121,9 +121,7 @@
                                 <span th:text="#{form.signin.label.send}">Sign In</span> <i class="fas fa-sign-in-alt"></i>
                             </button>
                             <a class="btn btn-dark mx-2" th:href="@{/oauth2/authorization/github}"><i class="fab fa-github"></i></a>
-                            <!--
-                            <a class="btn btn-danger"><i class="fab fa-google"></i></a>
-                            -->
+                            <a class="btn btn-danger" th:href="@{/oauth2/authorization/google}"><i class="fab fa-google"></i></a>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
 - Implemented support for Google based external authentication
 - Added relevant unit and acceptance test cases