### PR TITLE
LFLT-613 Migrate LAGS to Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 
 orbs:
-  jira: circleci/jira@1.3.1
-  jq: circleci/jq@2.2.0
+  jira: circleci/jira@2.1.0
+  jq: circleci/jq@3.0.0
+  gh: circleci/github-cli@2.3.0
 
 # Common parameters for CircleCI build config
 parameters:
@@ -36,21 +37,23 @@ commands:
         default: "rc"
         enum: ["rc", "release"]
     steps:
+      - checkout
       - attach_workspace:
           at: << pipeline.parameters.workspace_dir >>
+      - gh/setup
       - run:
           name: "Publish Release on GitHub"
           command: |
             [[ "<< parameters.release-type >>" = "release" ]] && VERSION_QUALIFIER="-release" || VERSION_QUALIFIER=""
             VERSION=v$(cat << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.version_file >>)$VERSION_QUALIFIER
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
+            gh release create ${VERSION} --target ${CIRCLE_SHA1} --title ${VERSION} << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
 
 jobs:
 
   # Leaflet Access Gateway Service - Build and test application
   build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0
     steps:
       - checkout
       - run:
@@ -97,8 +100,9 @@ jobs:
   # Leaflet Access Gateway Service - Deploy to production
   deploy:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0
     steps:
+      - checkout
       - attach_workspace:
           at: << pipeline.parameters.workspace_dir >>
       - run:
@@ -154,7 +158,7 @@ jobs:
   # Leaflet Access Gateway Service - Publish tag (and release) on GitHub for RC versions
   publish-github-rc:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cimg/base:stable
     steps:
       - github_release:
           release-type: rc
@@ -162,7 +166,7 @@ jobs:
   # Leaflet Access Gateway Service - Publish tag (and release) on GitHub for RELEASE versions
   publish-github-release:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cimg/base:stable
     steps:
       - github_release:
           release-type: release
@@ -180,8 +184,8 @@ workflows:
                - master
          post-steps:
            - jira/notify:
-               environment_type: development
-               job_type: build
+               pipeline_id: << pipeline.id >>
+               pipeline_number: << pipeline.number >>
 
       - publish-github-rc:
           context: leaflet_ci
@@ -199,8 +203,8 @@ workflows:
                 - deploy
           post-steps:
             - jira/notify:
-                environment_type: development
-                job_type: build
+                pipeline_id: << pipeline.id >>
+                pipeline_number: << pipeline.number >>
 
       - deploy-approval:
           context: leaflet_ci
@@ -214,8 +218,11 @@ workflows:
             - deploy-approval
           post-steps:
             - jira/notify:
+                environment: production
                 environment_type: production
                 job_type: deployment
+                pipeline_id: << pipeline.id >>
+                pipeline_number: << pipeline.number >>
 
       - publish-github-release:
           context: leaflet_ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 ARG APP_USER=leaflet
 ARG APP_HOME=/opt/lags

--- a/acceptance/pom.xml
+++ b/acceptance/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.1-dev</version>
+        <version>1.4.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -81,8 +81,8 @@
             <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
         </dependency>
 
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.1-dev</version>
+        <version>1.4.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/token/impl/JWTTokenHandlerTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/token/impl/JWTTokenHandlerTest.java
@@ -147,7 +147,7 @@ class JWTTokenHandlerTest {
 
         // then
         // exception expected
-        assertThat(result.getMessage().contains("Invalid unsecured/JWS/JWE header"), is(true));
+        assertThat(result.getMessage().contains("Malformed token"), is(true));
     }
 
     private void assertToken(String token, int expectedExpiration) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-access-gateway-service</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.1-dev</version>
+    <version>1.4.0-dev</version>
 
     <modules>
         <module>core</module>
@@ -25,7 +25,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>3.1-r2306.1</version>
+        <version>4.0-r2405.1</version>
     </parent>
 
     <properties>
@@ -35,7 +35,7 @@
         <spring.config.location>web/src/main/resources/application.yml</spring.config.location>
 
         <!-- Java environment version -->
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <!-- compiler settings -->
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -49,8 +49,8 @@
         <docker.skip>true</docker.skip>
 
         <!-- test dependency versions -->
-        <cucumber-java.version>7.6.0</cucumber-java.version>
-        <junit-platform-suite.version>1.9.0</junit-platform-suite.version>
+        <cucumber-java.version>7.18.0</cucumber-java.version>
+        <junit-platform-suite.version>1.10.2</junit-platform-suite.version>
 
     </properties>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.1-dev</version>
+        <version>1.4.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/BaseController.java
+++ b/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/BaseController.java
@@ -42,6 +42,7 @@ public class BaseController {
     public static final String PATH_OAUTH_INTROSPECT = "/oauth/introspect";
     public static final String PATH_WELL_KNOWN_JWKS = "/.well-known/jwks";
     public static final String PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER = "/.well-known/oauth-authorization-server";
+    public static final String PATH_WELL_KNOWN_OPENID_CONFIGURATION = "/.well-known/openid-configuration";
 
     private static final String VIEW_ERROR = "views/error";
 

--- a/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/WellKnownController.java
+++ b/web/src/main/java/hu/psprog/leaflet/lags/web/rest/controller/WellKnownController.java
@@ -4,14 +4,17 @@ import com.nimbusds.jose.jwk.JWKSet;
 import hu.psprog.leaflet.lags.web.model.AuthServerMetaInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 import static hu.psprog.leaflet.lags.web.rest.controller.BaseController.PATH_WELL_KNOWN_JWKS;
 import static hu.psprog.leaflet.lags.web.rest.controller.BaseController.PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER;
+import static hu.psprog.leaflet.lags.web.rest.controller.BaseController.PATH_WELL_KNOWN_OPENID_CONFIGURATION;
 
 /**
  * Controller for publicly available authorization server meta-information (.well-known) endpoints.
@@ -59,5 +62,16 @@ public class WellKnownController {
 
         return ResponseEntity
                 .ok(authServerMetaInfo);
+    }
+
+    /**
+     * GET /.well-known/openid-configuration
+     * Note: Required due to a recent change in Boot's error resolution. Statically returns 404, indicating that OpenID
+     * is not supported by the OAuth Authorization server.
+     */
+    @GetMapping(PATH_WELL_KNOWN_OPENID_CONFIGURATION)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public void getOpenIDConfiguration() {
+        log.debug("Unsupported OpenID configuration requested");
     }
 }


### PR DESCRIPTION
 - Added 404 controller entry point for OpenID configuration
 - Updated Java version to 21
 - Updated Dockerfile base image to Java 21
 - Changed stack base BOM version to 4.0-r2405.1
 - Updated CircleCI JIRA and GitHub integration
 - Bumped application version to 1.4.0-dev