### PR TITLE
LFLT-651 Spin up a secondary instance of LAGS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ parameters:
   app_name:
     type: string
     default: "lags"
+  app_name_standby_instance:
+    type: string
+    default: "lags-standby"
   release_tag_pattern:
     type: string
     default: 's/v[0-9]+\.[0-9]+\.[0-9]+\.([0-9]+)-release/\1/'
@@ -130,10 +133,21 @@ jobs:
           command: |
             set -e
             
-            echo "Using predefined access token"
+            echo "Requesting access token ..."
+            token="$(domino-cli --cicd auth --generate-token)" || exit 1
+            export DOMINO_CLI_PREAUTHORIZED_TOKEN=$token
+            
+            domino-cli --cicd import .domino/deployment-standby.yml
+            echo "Deployment definition successfully imported for hot-standby instance"
+            
+            domino-cli --cicd deploy << pipeline.parameters.app_name_standby_instance >> ${PROJECT_VERSION}
+            echo "Successfully deployed application << pipeline.parameters.app_name_standby_instance >> v${PROJECT_VERSION}"
+            
+            domino-cli --cicd start << pipeline.parameters.app_name_standby_instance >>
+            echo "Successfully started application << pipeline.parameters.app_name_standby_instance >>"
             
             domino-cli --cicd import
-            echo "Deployment definition successfully imported"
+            echo "Deployment definition successfully imported for live instance"
             
             domino-cli --cicd deploy << pipeline.parameters.app_name >> ${PROJECT_VERSION}
             echo "Successfully deployed application << pipeline.parameters.app_name >> v${PROJECT_VERSION}"
@@ -207,7 +221,7 @@ workflows:
       - deploy:
           context:
             - common-tech
-            - domino-direct-auth
+            - domino
           requires:
             - deploy-approval
           post-steps:

--- a/.domino/deployment-standby.yml
+++ b/.domino/deployment-standby.yml
@@ -1,0 +1,41 @@
+domino:
+  deployments:
+    lags-standby:
+      source:
+        type: DOCKER
+        home: "[dsm:common.home.docker]"
+        resource: lags
+      target:
+        hosts:
+          - psproghu
+      execution:
+        command-name: app_lags
+        via: STANDARD
+        args:
+          ports:
+            9185: 9085
+          network-mode: host
+          environment:
+            APP_ARGS: |
+              --spring.profiles.active=production
+              --spring.config.location=/opt/lags/appconfig_lags.yml
+              --server.port=9185
+          volumes:
+            "[dsm:volume.logs]": "/opt/lags/logs:rw"
+            "[dsm:volume.config.lags]": "/opt/lags/appconfig_lags.yml:ro"
+            "[dsm:volume.rsa]": "/opt/lags/rsa_keys:ro"
+            "/etc/timezone": "/etc/timezone:ro"
+            "/etc/localtime": "/etc/localtime:ro"
+          restart-policy: unless-stopped
+      health-check:
+        enabled: true
+        delay: 20 seconds
+        timeout: 2 seconds
+        max-attempts: 3
+        endpoint: "http://127.0.0.1:9185/actuator/health"
+      info:
+        enabled: true
+        endpoint: "http://127.0.0.1:9185/actuator/info"
+        field-mapping:
+          abbreviation: $.app.abbreviation
+          version: $.build.version


### PR DESCRIPTION
 - Added Domino deployment definition for standby instance
 - Updated CircleCI pipeline to deploy the standby instance before the primary
 - Switched to standard Domino authorization for the deployment step