### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  gh: circleci/github-cli@2.7.0
+  gh: circleci/github-cli@2.7.2
 
 # Common parameters for CircleCI build config
 parameters:
@@ -27,6 +27,9 @@ parameters:
   version_file:
     type: string
     default: "version"
+  deploy_name:
+    type: string
+    default: "prod-deploy-lags"
 
 # Reusable commands
 commands:
@@ -99,6 +102,15 @@ jobs:
             fi
           name: Push Docker image
       - run:
+          name: Plan deployment
+          command: |
+            if [[ $CIRCLE_BRANCH == "deploy" ]]; then
+              circleci run release plan << pipeline.parameters.deploy_name >> \
+                --environment-name=production \
+                --component-name=<< pipeline.parameters.app_name >> \
+                --target-version="${PROJECT_VERSION}"
+            fi
+      - run:
           command: |
             mkdir -p << pipeline.parameters.workspace_dir >>
             cp ./<< pipeline.parameters.executable_source_dir >><< pipeline.parameters.executable_file >> << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
@@ -133,12 +145,17 @@ jobs:
           command: |
             set -e
             
+            circleci run release update << pipeline.parameters.deploy_name >> --status=running
+            
             echo "Requesting access token ..."
             token="$(domino-cli --cicd auth --generate-token)" || exit 1
             export DOMINO_CLI_PREAUTHORIZED_TOKEN=$token
             
             domino-cli --cicd import .domino/deployment-standby.yml
             echo "Deployment definition successfully imported for hot-standby instance"
+            
+            domino-cli --cicd oauth-import << pipeline.parameters.app_name >>
+            echo "Deployment OAuth descriptor successfully imported"
             
             domino-cli --cicd deploy << pipeline.parameters.app_name_standby_instance >> ${PROJECT_VERSION}
             echo "Successfully deployed application << pipeline.parameters.app_name_standby_instance >> v${PROJECT_VERSION}"
@@ -156,6 +173,25 @@ jobs:
             echo "Successfully started application << pipeline.parameters.app_name >>"
 
           name: Deploy via Domino
+      - run:
+          name: Update planned release to SUCCESS
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update planned release to FAILED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=FAILED
+          when: on_fail
+
+  cancel-deploy:
+    executor: base
+    steps:
+      - run:
+          name: Update planned release to CANCELED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=CANCELED
+
 
   # Leaflet Access Gateway Service - Publish tag (and release) on GitHub for RC versions
   publish-github-rc:
@@ -231,6 +267,11 @@ workflows:
                 job_type: deployment
                 pipeline_id: << pipeline.id >>
                 pipeline_number: << pipeline.number >>
+
+      - cancel-deploy:
+          requires:
+            - deploy:
+                - canceled
 
       - publish-github-release:
           context:

--- a/.domino/deployment-standby.yml
+++ b/.domino/deployment-standby.yml
@@ -19,6 +19,8 @@ domino:
             APP_ARGS: |
               --spring.profiles.active=production
               --spring.config.location=/opt/lags/appconfig_lags.yml
+              --spring.datasource.username=[dsm:common.mysql.username]
+              --spring.datasource.password=[dsm:common.mysql.password]
               --server.port=9185
           volumes:
             "[dsm:volume.logs]": "/opt/lags/logs:rw"

--- a/.domino/deployment.yml
+++ b/.domino/deployment.yml
@@ -19,6 +19,8 @@ domino:
             APP_ARGS: |
               --spring.profiles.active=production
               --spring.config.location=/opt/lags/appconfig_lags.yml
+              --spring.datasource.username=[dsm:common.mysql.username]
+              --spring.datasource.password=[dsm:common.mysql.password]
           volumes:
             "[dsm:volume.logs]": "/opt/lags/logs:rw"
             "[dsm:volume.config.lags]": "/opt/lags/appconfig_lags.yml:ro"

--- a/.domino/oauth.yml
+++ b/.domino/oauth.yml
@@ -1,0 +1,49 @@
+domino:
+  oauth:
+    lags:
+      behavior:
+        target-provider: gateway-psproghu
+        roll-client-secret-on-deploy: true
+        use-secret-manager-for:
+          - client-secret
+          - client-id
+      tenant:
+        environment: prod
+        name: psproghu
+      client:
+        required-permissions:
+          - write:mail:pw_reset_confirmation
+          - write:mail:pw_reset_request
+          - write:mail:signup_confirmation
+          - write:mail:system_startup
+      resource-server:
+        use-audience: true
+        registered-permissions:
+          - read:access:applications
+          - read:access:permissions
+          - read:access:profile
+          - read:access:roles
+          - read:access:users
+          - write:access:applications
+          - write:access:permissions
+          - write:access:profile
+          - write:access:profile:delete
+          - write:access:roles
+          - write:access:users
+          - write:reclaim
+        allowed-clients:
+          - name: domino
+            allowed-permissions:
+              - read:access:applications
+              - read:access:permissions
+              - write:access:applications
+          - name: lpmc
+            allowed-permissions:
+              - read:access:applications
+              - read:access:permissions
+              - read:access:roles
+              - read:access:users
+              - write:access:applications
+              - write:access:permissions
+              - write:access:roles
+              - write:access:users

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ ARG APP_USER=leaflet
 ARG APP_HOME=/opt/lags
 ARG APP_EXECUTABLE=leaflet-access-gateway-exec.jar
 ENV ENV_APP_EXECUTABLE=$APP_EXECUTABLE
+ENV JAVA_OPTS="-Xmx128M"
 
 RUN addgroup --system --gid 1000 $APP_USER
 RUN adduser --system --no-create-home --gid 1000 --uid 1000 $APP_USER
 RUN mkdir -p $APP_HOME
 ADD web/target/$APP_EXECUTABLE $APP_HOME
-ADD config/leaflet-access-gateway-exec.conf $APP_HOME
 
 WORKDIR $APP_HOME
 RUN chmod 744 $APP_HOME
@@ -18,4 +18,4 @@ RUN chown -R $APP_USER:$APP_USER $APP_HOME
 
 USER $APP_USER
 
-ENTRYPOINT ./$ENV_APP_EXECUTABLE ${APP_ARGS}
+ENTRYPOINT exec java $JAVA_OPTS -jar $ENV_APP_EXECUTABLE ${APP_ARGS}

--- a/acceptance/pom.xml
+++ b/acceptance/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.1-dev</version>
+        <version>2.1.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -42,6 +42,14 @@
         </dependency>
 
         <!-- JUnit Platform dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-resttestclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite-engine</artifactId>
@@ -103,6 +111,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <argLine>-javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                     <properties>
                         <configurationParameters>
                             cucumber.junit-platform.naming-strategy=long

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/config/UtilityConfiguration.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/config/UtilityConfiguration.java
@@ -8,23 +8,27 @@ import hu.psprog.leaflet.recaptcha.api.client.ReCaptchaClient;
 import hu.psprog.leaflet.recaptcha.api.domain.ReCaptchaRequest;
 import hu.psprog.leaflet.recaptcha.api.domain.ReCaptchaResponse;
 import jakarta.annotation.PostConstruct;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.util.TimeValue;
 import org.jspecify.annotations.NonNull;
 import org.mockito.Mockito;
 import org.mockito.quality.Strictness;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.GenericWebApplicationContext;
-import wiremock.com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.withSettings;
@@ -81,8 +85,19 @@ public class UtilityConfiguration implements ApplicationContextAware {
     }
 
     @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+    public TestRestTemplate testRestTemplate() {
+
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        requestFactory.setHttpClient(HttpClientBuilder.create()
+                .disableAuthCaching()
+                .disableAutomaticRetries()
+                .disableConnectionState()
+                .disableCookieManagement()
+                .disableRedirectHandling()
+                .evictIdleConnections(TimeValue.ofSeconds(3L))
+                .build());
+
+        return new TestRestTemplate(new RestTemplateBuilder().requestFactory(() -> requestFactory));
     }
 
     @Override

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stub/ExternalAuthenticationMock.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/stub/ExternalAuthenticationMock.java
@@ -1,7 +1,5 @@
 package hu.psprog.leaflet.lags.acceptance.stub;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import hu.psprog.leaflet.lags.acceptance.model.TestConstants;
@@ -11,7 +9,9 @@ import hu.psprog.leaflet.lags.core.domain.internal.GitHubEmailItem;
 import hu.psprog.leaflet.lags.core.domain.response.OAuthTokenResponse;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.net.URI;
 import java.util.Collections;
@@ -25,7 +25,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
 import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * WireMock based mock server component for simulating external OAuth provider based login flows.
@@ -40,11 +39,11 @@ public class ExternalAuthenticationMock {
     private static final int EXTERNAL_USER_ID = 558890;
     private static final String EXTERNAL_USER_NAME = "Test User";
 
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
     private WireMockServer wireMockServer;
 
-    public ExternalAuthenticationMock(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public ExternalAuthenticationMock(JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
     }
 
     @PostConstruct
@@ -88,18 +87,14 @@ public class ExternalAuthenticationMock {
         URI location = ThreadLocalDataRegistry.getResponseEntity().getHeaders().getLocation();
         String scope = HTTPUtility.getQueryParameter(location, TestConstants.Attribute.SCOPE);
 
-        try {
-            String tokenResponse = objectMapper.writeValueAsString(OAuthTokenResponse.builder()
-                    .accessToken(UUID.randomUUID().toString())
-                    .expiresIn(EXPIRES_IN)
-                    .scope(scope)
-                    .build());
+        String tokenResponse = jsonMapper.writeValueAsString(OAuthTokenResponse.builder()
+                .accessToken(UUID.randomUUID().toString())
+                .expiresIn(EXPIRES_IN)
+                .scope(scope)
+                .build());
 
-            givenThat(post(tokenEndpoint)
-                    .willReturn(jsonResponse(tokenResponse, 200)));
-        } catch (JsonProcessingException e) {
-            fail("Failed to prepare mocked OAuth provider response");
-        }
+        givenThat(post(tokenEndpoint)
+                .willReturn(jsonResponse(tokenResponse, 200)));
     }
 
     private static void registerUserInfoEndpoint(String userInfoEndpoint) {
@@ -131,6 +126,7 @@ public class ExternalAuthenticationMock {
         return emailItem;
     }
 
+    @Getter
     public enum Provider {
 
         GITHUB("/githubmock/token", "/githubmock/userinfo", List.of(ExternalAuthenticationMock::registerGitHubEmailsEndpoint)),
@@ -146,16 +142,5 @@ public class ExternalAuthenticationMock {
             this.furtherRegistrations = furtherRegistrations;
         }
 
-        public String getTokenEndpoint() {
-            return tokenEndpoint;
-        }
-
-        public String getUserinfoEndpoint() {
-            return userinfoEndpoint;
-        }
-
-        public List<Runnable> getFurtherRegistrations() {
-            return furtherRegistrations;
-        }
     }
 }

--- a/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/utility/LAGSClient.java
+++ b/acceptance/src/test/java/hu/psprog/leaflet/lags/acceptance/utility/LAGSClient.java
@@ -11,7 +11,7 @@ import hu.psprog.leaflet.lags.core.exception.AuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/config/leaflet-access-gateway-exec.conf
+++ b/config/leaflet-access-gateway-exec.conf
@@ -1,1 +1,0 @@
-JAVA_OPTS=-Xmx128M

--- a/core/lombok.config
+++ b/core/lombok.config
@@ -1,0 +1,1 @@
+lombok.jacksonized.jacksonVersion += 3

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.1-dev</version>
+        <version>2.1.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/config/SecurityConfiguration.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/config/SecurityConfiguration.java
@@ -165,7 +165,7 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService,
-                                                   SavedRequestAwareAuthenticationSuccessHandler authenticationSuccessHandler) throws Exception {
+                                                   SavedRequestAwareAuthenticationSuccessHandler authenticationSuccessHandler) {
 
         return http
                 .addFilterBefore(new PasswordResetTokenCopyFilter(), UsernamePasswordAuthenticationFilter.class)
@@ -220,9 +220,8 @@ public class SecurityConfiguration {
     private AuthenticationProvider createAuthenticationProvider(PasswordEncoder passwordEncoder,
                                                                 UserDetailsService userDetailsService) {
 
-        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider(userDetailsService);
         authenticationProvider.setPasswordEncoder(passwordEncoder);
-        authenticationProvider.setUserDetailsService(userDetailsService);
 
         return authenticationProvider;
     }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/registry/impl/RSAKeyRegistry.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/registry/impl/RSAKeyRegistry.java
@@ -3,7 +3,6 @@ package hu.psprog.leaflet.lags.core.service.registry.impl;
 import hu.psprog.leaflet.lags.core.domain.config.OAuthConfigurationProperties;
 import hu.psprog.leaflet.lags.core.service.registry.KeyRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +19,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -112,6 +112,6 @@ public class RSAKeyRegistry implements KeyRegistry {
                 .skip(1)
                 .collect(Collectors.joining());
 
-        return Base64.decodeBase64(rsaKeyContent);
+        return Base64.getDecoder().decode(rsaKeyContent);
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactory.java
@@ -16,8 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import tools.jackson.core.type.TypeReference;
 
-import jakarta.ws.rs.core.GenericType;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -41,7 +41,7 @@ public class GitHubUserDataFactory implements UserDataFactory<Long> {
     private static final String ATTRIBUTE_USER_ID = "id";
     private static final String ATTRIBUTE_USERNAME = "name";
 
-    private static final GenericType<List<GitHubEmailItem>> GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE = new GenericType<>() {};
+    private static final TypeReference<List<GitHubEmailItem>> GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE = new TypeReference<>() {};
     private static final String PATH_USER_EMAILS = "/user/emails";
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String BEARER_TOKEN_TEMPLATE = "Bearer %s";

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/token/impl/JWTTokenHandlerTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/token/impl/JWTTokenHandlerTest.java
@@ -1,7 +1,5 @@
 package hu.psprog.leaflet.lags.core.service.token.impl;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import hu.psprog.leaflet.lags.core.domain.config.OAuthConfigTestHelper;
@@ -24,8 +22,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.security.interfaces.RSAPublicKey;
@@ -55,7 +54,7 @@ class JWTTokenHandlerTest {
     private static final OAuthConfigurationProperties O_AUTH_CONFIGURATION_PROPERTIES = prepareOAuthConfigurationProperties();
     private static final OAuthTokenRequest O_AUTH_TOKEN_REQUEST = prepareValidOAuthTokenRequest();
     private static final TokenClaims CLAIMS = prepareClaims();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = new JsonMapper();
     private static final String EMAIL = "user@dev.local";
     private static final String AUDIENCE = "target-svc-aud-1";
     private static final long USER_ID = 6643L;
@@ -83,7 +82,7 @@ class JWTTokenHandlerTest {
     }
 
     @Test
-    public void shouldGenerateTokenSuccessfullyCreateJWTToken() throws IOException {
+    public void shouldGenerateTokenSuccessfullyCreateJWTToken() {
 
         int expirationInSeconds = O_AUTH_CONFIGURATION_PROPERTIES.getToken().getExpiration();
 
@@ -99,7 +98,7 @@ class JWTTokenHandlerTest {
     }
 
     @Test
-    public void shouldGenerateTokenSuccessfullyCreateJWTTokenWithCustomExpiration() throws IOException {
+    public void shouldGenerateTokenSuccessfullyCreateJWTTokenWithCustomExpiration() {
 
         // given
         int customExpirationInSeconds = 600;
@@ -152,7 +151,7 @@ class JWTTokenHandlerTest {
         assertThat(result.getMessage().contains("Malformed token"), is(true));
     }
 
-    private void assertToken(String token, int expectedExpiration) throws IOException {
+    private void assertToken(String token, int expectedExpiration) {
 
         String[] tokenParts = token.split("\\.");
         assertThat(tokenParts.length, equalTo(3));
@@ -195,11 +194,11 @@ class JWTTokenHandlerTest {
         }
     }
 
-    private Map<String, Object> readTokenPart(String tokenPart) throws IOException {
+    private Map<String, Object> readTokenPart(String tokenPart) {
 
         byte[] decodedString = Base64.getDecoder().decode(tokenPart);
 
-        return OBJECT_MAPPER.readValue(decodedString, CLAIMS_TYPE_REFERENCE);
+        return JSON_MAPPER.readValue(decodedString, CLAIMS_TYPE_REFERENCE);
     }
 
     private static OAuthConfigurationProperties prepareOAuthConfigurationProperties() {

--- a/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactoryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lags/core/service/userdetails/external/impl/GitHubUserDataFactoryTest.java
@@ -22,8 +22,8 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import tools.jackson.core.type.TypeReference;
 
-import jakarta.ws.rs.core.GenericType;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +35,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
@@ -56,7 +55,7 @@ class GitHubUserDataFactoryTest {
     private static final OAuth2User OAUTH_USER = prepareOAuth2User();
     private static final ExternalUserDefinition<Long> EXPECTED_EXTERNAL_USER_DEFINITION = prepareExternalUserDefinition();
 
-    private static final GenericType<List<GitHubEmailItem>> GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE = new GenericType<>() {};
+    private static final TypeReference<List<GitHubEmailItem>> GITHUB_API_EMAIL_ENDPOINT_TYPE_REFERENCE = new TypeReference<>() {};
     private static final List<GitHubEmailItem> GITHUB_EMAIL_ITEMS = prepareGitHubEmailResponse(true);
     private static final List<GitHubEmailItem> GITHUB_EMAIL_ITEMS_WITHOUT_PRIMARY = prepareGitHubEmailResponse(false);
 
@@ -66,6 +65,9 @@ class GitHubUserDataFactoryTest {
     @Captor
     private ArgumentCaptor<RESTRequest> restRequestCaptor;
 
+    @Captor
+    private ArgumentCaptor<TypeReference<List<GitHubEmailItem>>> typeReferenceCaptor;
+
     @InjectMocks
     private GitHubUserDataFactory gitHubUserDataFactory;
 
@@ -73,7 +75,7 @@ class GitHubUserDataFactoryTest {
     public void shouldCreateUserDefinitionProcessRequestSuccessfully() throws CommunicationFailureException {
 
         // given
-        given(bridgeClient.call(restRequestCaptor.capture(), eq(GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE))).willReturn(GITHUB_EMAIL_ITEMS);
+        given(bridgeClient.call(restRequestCaptor.capture(), typeReferenceCaptor.capture())).willReturn(GITHUB_EMAIL_ITEMS);
 
         // when
         ExternalUserDefinition<Long> result = gitHubUserDataFactory.createUserDefinition(OAUTH_USER_REQUEST, OAUTH_USER);
@@ -81,32 +83,35 @@ class GitHubUserDataFactoryTest {
         // then
         assertThat(result, equalTo(EXPECTED_EXTERNAL_USER_DEFINITION));
         assertRESTRequest(restRequestCaptor.getValue());
+        assertThat(typeReferenceCaptor.getValue().getType(), equalTo(GITHUB_API_EMAIL_ENDPOINT_TYPE_REFERENCE.getType()));
     }
 
     @Test
     public void shouldCreateUserDefinitionFailForExternalUserNotHavingPrimaryEmailAddress() throws CommunicationFailureException {
 
         // given
-        given(bridgeClient.call(any(), eq(GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE))).willReturn(GITHUB_EMAIL_ITEMS_WITHOUT_PRIMARY);
+        given(bridgeClient.call(any(), typeReferenceCaptor.capture())).willReturn(GITHUB_EMAIL_ITEMS_WITHOUT_PRIMARY);
 
         // when
         assertThrows(ExternalAuthenticationException.class, () -> gitHubUserDataFactory.createUserDefinition(OAUTH_USER_REQUEST, OAUTH_USER));
 
         // then
         // exception expected
+        assertThat(typeReferenceCaptor.getValue().getType(), equalTo(GITHUB_API_EMAIL_ENDPOINT_TYPE_REFERENCE.getType()));
     }
 
     @Test
     public void shouldCreateUserDefinitionFailWhenContactGitHubAPIFails() throws CommunicationFailureException {
 
         // given
-        doThrow(ForbiddenOperationException.class).when(bridgeClient).call(any(), eq(GITHUB_API_EMAIL_ENDPOINT_GENERIC_TYPE));
+        doThrow(ForbiddenOperationException.class).when(bridgeClient).call(any(), typeReferenceCaptor.capture());
 
         // when
         assertThrows(ExternalAuthenticationException.class, () -> gitHubUserDataFactory.createUserDefinition(OAUTH_USER_REQUEST, OAUTH_USER));
 
         // then
         // exception expected
+        assertThat(typeReferenceCaptor.getValue().getType(), equalTo(GITHUB_API_EMAIL_ENDPOINT_TYPE_REFERENCE.getType()));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-access-gateway-service</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1-dev</version>
+    <version>2.1.0-dev</version>
 
     <modules>
         <module>core</module>
@@ -25,7 +25,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.3</version>
     </parent>
 
     <properties>
@@ -50,7 +50,7 @@
         <docker.skip-latest>true</docker.skip-latest>
 
         <!-- test dependency versions -->
-        <cucumber-java.version>7.22.1</cucumber-java.version>
+        <cucumber-java.version>7.34.3</cucumber-java.version>
 
     </properties>
 
@@ -92,11 +92,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                    <proc>full</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-access-gateway-service</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.1-dev</version>
+        <version>2.1.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,10 +26,6 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
         <dependency>
-            <groupId>nz.net.ultraq.thymeleaf</groupId>
-            <artifactId>thymeleaf-layout-dialect</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
@@ -43,20 +39,24 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>hu.psprog.leaflet</groupId>
             <artifactId>leaflet-translation-adapter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
+            <groupId>nz.net.ultraq.thymeleaf</groupId>
+            <artifactId>thymeleaf-layout-dialect</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
     </dependencies>
 
@@ -72,7 +72,6 @@
                         <argument>--spring.profiles.active=${spring.profiles.active}</argument>
                         <argument>--spring.config.location=${spring.config.location}</argument>
                     </arguments>
-                    <executable>true</executable>
                 </configuration>
                 <executions>
                     <execution>

--- a/web/src/main/resources/banner.txt
+++ b/web/src/main/resources/banner.txt
@@ -4,3 +4,5 @@
                 _/        _/_/_/_/  _/  _/_/    _/_/
                _/        _/    _/  _/    _/        _/
               _/_/_/_/  _/    _/    _/_/_/  _/_/_/
+
+          --== Powered by Spring Boot v${spring-boot.version} ==--

--- a/web/src/test/java/hu/psprog/leaflet/lags/web/rest/controller/WellKnownControllerTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/lags/web/rest/controller/WellKnownControllerTest.java
@@ -1,8 +1,5 @@
 package hu.psprog.leaflet.lags.web.rest.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.JWKSet;
 import hu.psprog.leaflet.lags.web.model.AuthServerMetaInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +9,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
 import java.util.Map;
@@ -37,14 +36,14 @@ class WellKnownControllerTest {
     @Mock
     private JWKSet jwkSet;
 
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     private WellKnownController wellKnownController;
 
     @BeforeEach
     public void setup() {
         wellKnownController = new WellKnownController(jwkSet, AUTH_SERVER_META_INFO);
-        objectMapper = new ObjectMapper();
+        jsonMapper = new JsonMapper();
     }
 
     @Test
@@ -63,7 +62,7 @@ class WellKnownControllerTest {
     }
 
     @Test
-    public void shouldGetServerMetaInfoReturnExposedMetaInfo() throws JsonProcessingException {
+    public void shouldGetServerMetaInfoReturnExposedMetaInfo() {
 
         // when
         ResponseEntity<AuthServerMetaInfo> result = wellKnownController.getServerMetaInfo();
@@ -74,10 +73,10 @@ class WellKnownControllerTest {
         assertResultAsJSON(result.getBody());
     }
 
-    private void assertResultAsJSON(AuthServerMetaInfo authServerMetaInfo) throws JsonProcessingException {
+    private void assertResultAsJSON(AuthServerMetaInfo authServerMetaInfo) {
 
-        String jsonString = objectMapper.writeValueAsString(authServerMetaInfo);
-        Map<String, Object> deserialized = objectMapper.readValue(jsonString, MAP_TYPE_REFERENCE);
+        String jsonString = jsonMapper.writeValueAsString(authServerMetaInfo);
+        Map<String, Object> deserialized = jsonMapper.readValue(jsonString, MAP_TYPE_REFERENCE);
 
         assertThat(deserialized, equalTo(Map.of(
                 "issuer", "http://localhost:9999",


### PR DESCRIPTION
 - Aligned Jackson imports and configuration
 - Eliminated deprecated calls
 - Switched to stack base BOM v6.0-r2604.3
 - Bumped application version to 2.1.0-dev
 - POM fixes (annotation processing and Mockito warnings)
 - Added OAuth application descriptor and import step in pipeline
 - Added deploy markers to CircleCI config